### PR TITLE
ignore personal files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,9 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+/idp.crt
+/idp.key
+/metadata.xml
+/users.json
+/config.yaml


### PR DESCRIPTION
Questi file sono solitamente file di configurazione personali, ingorandoli si riduce il rischio di aggiungerli al repository in futuro