### PR TITLE
Fix flake8 and conform spacing to pep8.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [flake8]
 exclude = *.egg-info
 max-line-length = 119
+ignore = 
+  E501  # Line too long
+  
 
 [isort]
 line_length = 119

--- a/testenv/config.py
+++ b/testenv/config.py
@@ -12,6 +12,7 @@ from testenv.exceptions import BadConfiguration
 
 
 class ConfigValidator(object):
+
     def __init__(self, confdata):
         self._confdata = confdata
         self._init_schema()
@@ -53,7 +54,8 @@ class ConfigValidator(object):
             key_path = data.get('https_key_file')
             cert_path = data.get('https_cert_file')
             if https and not all([key_path, cert_path]):
-                raise Invalid('Errore modalità HTTPS: chiave e/o certificato assenti')
+                raise Invalid(
+                    'Errore modalità HTTPS: chiave e/o certificato assenti')
             return data
 
         def check_endpoints(data):
@@ -90,6 +92,7 @@ class ConfigValidator(object):
 
 
 class Config(object):
+
     def __init__(self, confdata):
         self._confdata = confdata
         self._idp_key = self._load_idp_key()
@@ -99,7 +102,8 @@ class Config(object):
         try:
             return self._read_file_bytes(self.idp_key_file_path)
         except Exception:
-            self._fail('Impossibile ottenere la chiave privata dal file {}'.format(self.key_file_path))
+            self._fail('Impossibile ottenere la chiave privata dal file {}'.format(
+                self.key_file_path))
 
     @staticmethod
     def _read_file_bytes(path):
@@ -118,7 +122,8 @@ class Config(object):
         try:
             return self._read_file_bytes(self.idp_certificate_file_path)
         except Exception:
-            self._fail('Impossibile ottenere il certificato dal file {}'.format(self.cert_file_path))
+            self._fail('Impossibile ottenere il certificato dal file {}'.format(
+                self.cert_file_path))
 
     @property
     def idp_certificate_file_path(self):
@@ -233,6 +238,7 @@ class Config(object):
 
 
 class BaseConfigParser(object):
+
     def __init__(self, path):
         self._path = path
         self._fp = None
@@ -241,9 +247,11 @@ class BaseConfigParser(object):
         try:
             return self._parse()
         except OSError:
-            raise BadConfiguration('Impossibile accedere al file di configurazione: {}'.format(self._path))
+            raise BadConfiguration(
+                'Impossibile accedere al file di configurazione: {}'.format(self._path))
         except Exception:
-            raise BadConfiguration('Errore di sintassi nel file di configurazione: {}'.format(self._path))
+            raise BadConfiguration(
+                'Errore di sintassi nel file di configurazione: {}'.format(self._path))
 
     def _parse(self):
         with open(self._path, 'r') as fp:
@@ -252,11 +260,13 @@ class BaseConfigParser(object):
 
 
 class YAMLConfigParser(BaseConfigParser):
+
     def _deserialize(self):
         return yaml.load(self._fp)
 
 
 class JSONConfigParser(BaseConfigParser):
+
     def _deserialize(self):
         return json.load(self._fp.read())
 

--- a/testenv/crypto.py
+++ b/testenv/crypto.py
@@ -56,6 +56,7 @@ def normalize_x509(cert):
 
 
 class RSASigner(object):
+
     def __init__(self, digest, key=None, padding=None):
         self._key = key
         self._digest = digest
@@ -68,6 +69,7 @@ class RSASigner(object):
 
 
 class RSAVerifier(object):
+
     def __init__(self, digest, padding=None):
         self._digest = digest
         self._padding = padding or PKCS1v15()
@@ -141,6 +143,7 @@ def sign_http_redirect(xmlstr, key, relay_state=None, req_type='SAMLResponse'):
 
 
 class HTTPRedirectSignatureVerifier(object):
+
     def __init__(self, certificate, request, verifiers=None):
         self._cert = certificate
         self._request = request
@@ -192,6 +195,7 @@ class HTTPRedirectSignatureVerifier(object):
 
 
 class HTTPPostSignatureVerifier(object):
+
     def __init__(self, certificate, request, verifier=None):
         self._cert = certificate
         self._request = request

--- a/testenv/exceptions.py
+++ b/testenv/exceptions.py
@@ -15,6 +15,7 @@ class RequestParserError(TestenvError):
 
 
 class DeserializationError(TestenvError):
+
     def __init__(self, initial_data, details):
         super(DeserializationError, self).__init__()
         self.initial_data = initial_data
@@ -58,6 +59,7 @@ class UnknownEntityIDError(TestenvError):
 
 
 class MetadataNotFoundError(TestenvError):
+
     def __init__(self, entity_id):
         self.entity_id = entity_id
 

--- a/testenv/parser.py
+++ b/testenv/parser.py
@@ -27,7 +27,8 @@ HTTPRedirectRequest = namedtuple(
 )
 
 
-HTTPPostRequest = namedtuple('HTTPPostRequest', ['saml_request', 'relay_state'])
+HTTPPostRequest = namedtuple(
+    'HTTPPostRequest', ['saml_request', 'relay_state'])
 
 
 def _get_deserializer(request, action, binding):
@@ -49,6 +50,7 @@ def get_http_post_request_deserializer(request, action):
 
 
 class HTTPRedirectRequestParser(object):
+
     def __init__(self, querystring, request_class=None):
         self._querystring = querystring
         self._request_class = request_class or HTTPRedirectRequest
@@ -130,6 +132,7 @@ class HTTPRedirectRequestParser(object):
 
 
 class HTTPPostRequestParser(object):
+
     def __init__(self, form, request_class=None):
         self._form = form
         self._request_class = request_class or HTTPPostRequest
@@ -177,6 +180,7 @@ class HTTPPostRequestParser(object):
 
 
 class HTTPRequestDeserializer(object):
+
     def __init__(self, request, validator, saml_class=None):
         self._request = request
         self._validator = validator
@@ -201,6 +205,7 @@ class HTTPRequestDeserializer(object):
 
 
 class SAMLTree(object):
+
     def __init__(self, xml_doc, multi_occur_tags=None):
         self._xml_doc = xml_doc
         self._multi_occur_tags = multi_occur_tags or MULTIPLE_OCCURRENCES_TAGS

--- a/testenv/saml.py
+++ b/testenv/saml.py
@@ -276,7 +276,7 @@ def create_response(data, response_status, attributes={}):
             InResponseTo=response_attrs.get('in_response_to')
         )
     )
-    
+
     # Setup issuer data
     issuer_attrs = data.get('issuer').get('attrs')
     issuer = Issuer(
@@ -286,7 +286,7 @@ def create_response(data, response_status, attributes={}):
         text=data.get('issuer').get('text')
     )
     response.append(issuer)
-    
+
     # Setup status data
     status = Status()
     status_code_value = response_status.get('status_code')
@@ -297,7 +297,7 @@ def create_response(data, response_status, attributes={}):
     )
     status.append(status_code)
     response.append(status)
-    
+
     # Create and setup the assertion
     assertion = Assertion(
         attrib=dict(
@@ -316,7 +316,8 @@ def create_response(data, response_status, attributes={}):
     )
     subject.append(name_id)
     subject_confirmation = SubjectConfirmation()
-    subject_confirmation_data_attrs = data.get('subject_confirmation_data').get('attrs')
+    subject_confirmation_data_attrs = data.get(
+        'subject_confirmation_data').get('attrs')
     subject_confirmation_data = SubjectConfirmationData(
         attrib=dict(
             Recipient=subject_confirmation_data_attrs.get('recipient'),
@@ -489,7 +490,6 @@ class ServiceName(SamlMixin):
 
 class RequestedAttribute(SamlMixin):
     saml_type = 'md'
-
 
 
 def create_idp_metadata(

--- a/testenv/server.py
+++ b/testenv/server.py
@@ -127,7 +127,8 @@ class IdpServer(object):
         :param kwargs: dictionary, extra arguments
         """
         level = self._spid_levels.index(level)
-        self.app.logger.debug('spid level {} - verifica ({})'.format(level, verify))
+        self.app.logger.debug(
+            'spid level {} - verifica ({})'.format(level, verify))
         if verify:
             # Verify the challenge
             if level == 2:
@@ -156,9 +157,9 @@ class IdpServer(object):
                 otp = ''.join(random.choice(string.digits) for _ in range(6))
                 self.challenges[key] = [otp, datetime.now()]
                 extra_challenge = '<span>Otp ({})</span>'\
-                '<input type="text" name="otp" />'.format(
-                    otp
-                )
+                    '<input type="text" name="otp" />'.format(
+                        otp
+                    )
             else:
                 extra_challenge = ''
             return extra_challenge
@@ -179,7 +180,7 @@ class IdpServer(object):
 
         abort(
             Response(
-               render_template(
+                render_template(
                     "error.html",
                     **{'msg': msg, 'extra': extra or ""}
                 ), 200
@@ -206,8 +207,8 @@ class IdpServer(object):
             **{
                 'lines': xmlstr.splitlines(),
                 'errors': errors
-                }
-            )
+            }
+        )
         return rendered_error_response
 
     def _parse_message(self, action):
@@ -236,7 +237,8 @@ class IdpServer(object):
         # about request parsing *at all*.
         saml_msg = self.unpack_args(request.args)
         request_data = HTTPRedirectRequestParser(saml_msg).parse()
-        deserializer = get_http_redirect_request_deserializer(request_data, action)
+        deserializer = get_http_redirect_request_deserializer(
+            request_data, action)
         saml_tree = deserializer.deserialize()
         certs = self._get_certificates_by_issuer(saml_tree.issuer.text)
         if not certs:
@@ -267,12 +269,12 @@ class IdpServer(object):
             return self._registry.get(issuer).certs()
         except KeyError:
             self._raise_error(
-                'entity ID {} non registrato, impossibile ricavare'\
+                'entity ID {} non registrato, impossibile ricavare'
                 ' un certificato valido.'.format(issuer)
             )
         except NoCertificateError:
             self._raise_error(
-                'Errore, il metadata associato al Service provider non'\
+                'Errore, il metadata associato al Service provider non'
                 ' non è provvisto di certificati validi'.format(issuer)
             )
 
@@ -357,7 +359,8 @@ class IdpServer(object):
                 if spid_value:
                     extra[spid_field] = spid_value
             if 'fiscalNumber' in extra:
-                extra['fiscalNumber'] = 'TINIT-{}'.format(extra['fiscalNumber'])
+                extra[
+                    'fiscalNumber'] = 'TINIT-{}'.format(extra['fiscalNumber'])
             self.user_manager.add(username, password, sp, extra.copy())
         return redirect(url_for('users'))
 
@@ -379,7 +382,8 @@ class IdpServer(object):
         acs_index = getattr(req, 'assertion_consumer_service_index', None)
         protocol_binding = getattr(req, 'protocol_binding', None)
         if acs_index is not None:
-            acss = self._registry.get(sp_id).assertion_consumer_service(index=acs_index)
+            acss = self._registry.get(
+                sp_id).assertion_consumer_service(index=acs_index)
             if acss:
                 destination = acss[0].get('Location')
             self.app.logger.debug(
@@ -420,7 +424,8 @@ class IdpServer(object):
             spid_level = authn_context.authn_context_class_ref.text
             if request.method == 'GET':
                 # inject extra data in form login based on spid level
-                extra_challenge = self._verify_spid(level=spid_level, **{'key': key})
+                extra_challenge = self._verify_spid(
+                    level=spid_level, **{'key': key})
                 rendered_form = render_template(
                     'login.html',
                     **{
@@ -453,7 +458,8 @@ class IdpServer(object):
                         self.app.logger.debug(
                             'Unfiltered data: {}'.format(identity)
                         )
-                        atcs_idx = getattr(authn_request, 'attribute_consuming_service_index', None)
+                        atcs_idx = getattr(
+                            authn_request, 'attribute_consuming_service_index', None)
                         self.app.logger.debug(
                             'AttributeConsumingServiceIndex: {}'.format(
                                 atcs_idx
@@ -477,12 +483,14 @@ class IdpServer(object):
                             try:
                                 _identity[_key] = identity[_key]
                             except KeyError:
-                                _identity[_key] = ('', self._attribute_type(_key))
+                                _identity[_key] = (
+                                    '', self._attribute_type(_key))
                         for _key in optional:
                             try:
                                 _identity[_key] = identity[_key]
                             except KeyError:
-                                _identity[_key] = ('', self._attribute_type(_key))
+                                _identity[_key] = (
+                                    '', self._attribute_type(_key))
 
                         self.app.logger.debug(
                             'Filtered data: {}'.format(_identity)
@@ -615,8 +623,8 @@ class IdpServer(object):
                     auth_req, auth_req.issuer.text
                 )
                 error_info = get_spid_error(
-                        AUTH_NO_CONSENT
-                    )
+                    AUTH_NO_CONSENT
+                )
                 response = create_error_response(
                     {
                         'response': {
@@ -661,7 +669,8 @@ class IdpServer(object):
         _slo = None
         for binding in [BINDING_HTTP_POST, BINDING_HTTP_REDIRECT]:
             try:
-                _slo = self._registry.get(issuer_name).single_logout_services[0]
+                _slo = self._registry.get(
+                    issuer_name).single_logout_services[0]
             except Exception:
                 pass
         return _slo
@@ -678,7 +687,7 @@ class IdpServer(object):
             _slo = self._sp_single_logout_service(issuer_name)
             if _slo is None:
                 self._raise_error(
-                    'Impossibile trovare un servizio di'\
+                    'Impossibile trovare un servizio di'
                     ' Single Logout per il service provider {}'.format(
                         issuer_name
                     )

--- a/testenv/settings.py
+++ b/testenv/settings.py
@@ -68,7 +68,7 @@ XSI = 'http://www.w3.org/2001/XMLSchema-instance'
 XS = 'http://www.w3.org/2001/XMLSchema'
 MD = 'urn:oasis:names:tc:SAML:2.0:metadata'
 
-NSMAP = { 'saml':  SAML, 'samlp': SAMLP, 'ds': DS, 'md': MD}
+NSMAP = {'saml': SAML, 'samlp': SAMLP, 'ds': DS, 'md': MD}
 NAME_FORMAT_BASIC = 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic'
 NAMEID_FORMAT_TRANSIENT = 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
 NAMEID_FORMAT_ENTITY = 'urn:oasis:names:tc:SAML:2.0:nameid-format:entity'
@@ -98,7 +98,8 @@ SIG_RSA_SHA256 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
 SIG_RSA_SHA384 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384'
 SIG_RSA_SHA512 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'
 DEPRECATED_ALGORITHMS = [SIG_RSA_SHA1]
-SUPPORTED_ALGORITHMS = [SIG_RSA_SHA224, SIG_RSA_SHA256, SIG_RSA_SHA384, SIG_RSA_SHA512]
+SUPPORTED_ALGORITHMS = [SIG_RSA_SHA224,
+                        SIG_RSA_SHA256, SIG_RSA_SHA384, SIG_RSA_SHA512]
 
 SIG_NS = '{http://www.w3.org/2000/09/xmldsig#}'
 
@@ -115,8 +116,9 @@ SIGNED_PARAMS = ['SAMLRequest', 'SAMLResponse', 'RelayState', 'SigAlg']
 
 
 # Misc
-TIMEDELTA = 2 # minutes (used to verify and generate range limits for issue instant etc.)
-CHALLENGES_TIMEOUT = 30 # seconds (used to verify spid level >= 2 challenges)
+# minutes (used to verify and generate range limits for issue instant etc.)
+TIMEDELTA = 2
+CHALLENGES_TIMEOUT = 30  # seconds (used to verify spid level >= 2 challenges)
 
 MULTIPLE_OCCURRENCES_TAGS = {
     '{%s}AssertionConsumerService' % (MD),

--- a/testenv/spmetadata.py
+++ b/testenv/spmetadata.py
@@ -29,6 +29,7 @@ SINGLE_LOGOUT_SERVICE = SingleLogoutService.tag()
 
 
 class ServiceProviderMetadataBaseLoader(object):
+
     def __init__(self, conf, validator):
         self._config = conf
         self._validator = validator
@@ -46,6 +47,7 @@ class ServiceProviderMetadataBaseLoader(object):
 
 
 class ServiceProviderMetadataFileLoader(ServiceProviderMetadataBaseLoader):
+
     def _load(self):
         try:
             return self._read_file_text()
@@ -62,6 +64,7 @@ class ServiceProviderMetadataFileLoader(ServiceProviderMetadataBaseLoader):
 
 
 class ServiceProviderMetadataHTTPLoader(ServiceProviderMetadataBaseLoader):
+
     def _load(self):
         try:
             return self._make_request()
@@ -78,6 +81,7 @@ class ServiceProviderMetadataHTTPLoader(ServiceProviderMetadataBaseLoader):
 
 
 class ServiceProviderMetadata(object):
+
     def __init__(self, loader):
         self._loader = loader
 
@@ -101,7 +105,7 @@ class ServiceProviderMetadata(object):
         key_descriptors = self.root.get(
             'children', {}
         ).get(SPSSODESCRIPTOR, {}
-        ).get(
+              ).get(
             'children', {}
         ).get(
             KEYDESCRIPTOR, []
@@ -112,7 +116,7 @@ class ServiceProviderMetadata(object):
                 'children', {}
             )
             if key_descriptor.get('attrs', {}
-            ).get('use') == use:
+                                  ).get('use') == use:
                 _cert = _key_descriptor.get(
                     KEYINFO, {}
                 ).get(
@@ -135,7 +139,7 @@ class ServiceProviderMetadata(object):
         acss = self.root.get(
             'children', {}
         ).get(SPSSODESCRIPTOR, {}
-        ).get(
+              ).get(
             'children', {}
         ).get(
             ASSERTION_CONSUMER_SERVICE, []
@@ -147,10 +151,10 @@ class ServiceProviderMetadata(object):
     def assertion_consumer_service(self, binding=None, index=None):
         return [
             acs for acs in self.assertion_consumer_services if (
-                    binding is not None and acs.get('Binding') == binding
-                ) or (
-                    index is not None and acs.get('index') == index
-                )
+                binding is not None and acs.get('Binding') == binding
+            ) or (
+                index is not None and acs.get('index') == index
+            )
         ]
 
     @property
@@ -158,7 +162,7 @@ class ServiceProviderMetadata(object):
         return self.root.get(
             'children', {}
         ).get(SPSSODESCRIPTOR, {}
-        ).get(
+              ).get(
             'children', {}
         ).get(
             ATTRIBUTE_CONSUMING_SERVICE, []
@@ -182,7 +186,7 @@ class ServiceProviderMetadata(object):
             requested_attributes = service.get(
                 'children', {}
             ).get(REQUESTEDATTRIBUTE, []
-            )
+                  )
             for requested_attribute in requested_attributes:
                 _attrs = requested_attribute.get(
                     'attrs', {}
@@ -200,7 +204,7 @@ class ServiceProviderMetadata(object):
         slos = self.root.get(
             'children', {}
         ).get(SPSSODESCRIPTOR, {}
-        ).get(
+              ).get(
             'children', {}
         ).get(
             SINGLE_LOGOUT_SERVICE, []
@@ -221,6 +225,7 @@ class ServiceProviderMetadata(object):
 
 
 class ServiceProviderMetadataRegistry(object):
+
     def __init__(self):
         self._metadata = {}
 
@@ -228,7 +233,8 @@ class ServiceProviderMetadataRegistry(object):
         try:
             self._register(metadata)
         except MetadataLoadError as e:
-            logger.error("Impossibile aggiungere metadata al registry: '{}'".format(e))
+            logger.error(
+                "Impossibile aggiungere metadata al registry: '{}'".format(e))
 
     def _register(self, metadata):
         entity_id = metadata.entity_id
@@ -267,5 +273,6 @@ def _get_loader(source_type, source_params):
         'local': ServiceProviderMetadataFileLoader,
         'remote': ServiceProviderMetadataHTTPLoader,
     }[source_type]
-    validator = ValidatorGroup([XMLMetadataFormatValidator(), ServiceProviderMetadataXMLSchemaValidator()])
+    validator = ValidatorGroup(
+        [XMLMetadataFormatValidator(), ServiceProviderMetadataXMLSchemaValidator()])
     return Loader(source_params, validator)

--- a/testenv/tests/data/sample_saml_requests.py
+++ b/testenv/tests/data/sample_saml_requests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 valid = [
 
     """\

--- a/testenv/tests/test_crypto.py
+++ b/testenv/tests/test_crypto.py
@@ -93,7 +93,8 @@ class HTTPRedirectSignatureVerifierTestCase(unittest.TestCase):
         self.assertIsNone(verifier.verify())
 
     def test_deprecated_algorithm(self):
-        self.request_data['sig_alg'] = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+        self.request_data[
+            'sig_alg'] = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
         request = HTTPRedirectRequest(**self.request_data)
         verifier = HTTPRedirectSignatureVerifier(self.cert, request)
         with pytest.raises(SignatureVerificationError) as excinfo:
@@ -101,7 +102,8 @@ class HTTPRedirectSignatureVerifierTestCase(unittest.TestCase):
         exc = excinfo.value
         self.assertEqual(
             "L'algoritmo 'http://www.w3.org/2000/09/xmldsig#rsa-sha1' è considerato deprecato. "
-            "Si prega di utilizzare uno dei seguenti: {}".format(self.supported_sig_alg),
+            "Si prega di utilizzare uno dei seguenti: {}".format(
+                self.supported_sig_alg),
             exc.args[0]
         )
 
@@ -189,11 +191,13 @@ class HTTPPostSignatureVerifierTestCase(unittest.TestCase):
         saml_request = self.saml_request.format(
             break_digest='',
             signature_value=self.signature_value,
-            signed_info=self.signed_info.format(sig_alg=self.sig_alg, break_signature=''),
+            signed_info=self.signed_info.format(
+                sig_alg=self.sig_alg, break_signature=''),
             certificate=self.cert,
         )
         relay_state = 'relay_state'
-        request = HTTPPostRequest(saml_request=saml_request, relay_state=relay_state)
+        request = HTTPPostRequest(
+            saml_request=saml_request, relay_state=relay_state)
         verifier = HTTPPostSignatureVerifier(self.cert, request)
         self.assertIsNone(verifier.verify())
 
@@ -202,18 +206,21 @@ class HTTPPostSignatureVerifierTestCase(unittest.TestCase):
         saml_request = self.saml_request.format(
             break_digest='',
             signature_value=self.signature_value,
-            signed_info=self.signed_info.format(sig_alg=sig_alg, break_signature=''),
+            signed_info=self.signed_info.format(
+                sig_alg=sig_alg, break_signature=''),
             certificate=self.cert,
         )
         relay_state = 'relay_state'
-        request = HTTPPostRequest(saml_request=saml_request, relay_state=relay_state)
+        request = HTTPPostRequest(
+            saml_request=saml_request, relay_state=relay_state)
         verifier = HTTPPostSignatureVerifier(self.cert, request)
         with pytest.raises(SignatureVerificationError) as excinfo:
             verifier.verify()
         exc = excinfo.value
         self.assertEqual(
             "L'algoritmo 'http://www.w3.org/2000/09/xmldsig#rsa-sha1' è considerato deprecato. "
-            "Si prega di utilizzare uno dei seguenti: {}".format(self.supported_sig_alg),
+            "Si prega di utilizzare uno dei seguenti: {}".format(
+                self.supported_sig_alg),
             exc.args[0]
         )
 
@@ -222,11 +229,13 @@ class HTTPPostSignatureVerifierTestCase(unittest.TestCase):
         saml_request = self.saml_request.format(
             break_digest='',
             signature_value=self.signature_value,
-            signed_info=self.signed_info.format(sig_alg=sig_alg, break_signature=''),
+            signed_info=self.signed_info.format(
+                sig_alg=sig_alg, break_signature=''),
             certificate=self.cert,
         )
         relay_state = 'relay_state'
-        request = HTTPPostRequest(saml_request=saml_request, relay_state=relay_state)
+        request = HTTPPostRequest(
+            saml_request=saml_request, relay_state=relay_state)
         verifier = HTTPPostSignatureVerifier(self.cert, request)
         with pytest.raises(SignatureVerificationError) as excinfo:
             verifier.verify()
@@ -241,11 +250,13 @@ class HTTPPostSignatureVerifierTestCase(unittest.TestCase):
         saml_request = self.saml_request.format(
             break_digest='',
             signature_value=self.signature_value,
-            signed_info=self.signed_info.format(sig_alg=self.sig_alg, break_signature=''),
+            signed_info=self.signed_info.format(
+                sig_alg=self.sig_alg, break_signature=''),
             certificate='fake cert',
         )
         relay_state = 'relay_state'
-        request = HTTPPostRequest(saml_request=saml_request, relay_state=relay_state)
+        request = HTTPPostRequest(
+            saml_request=saml_request, relay_state=relay_state)
         verifier = HTTPPostSignatureVerifier(self.cert, request)
         with pytest.raises(SignatureVerificationError) as excinfo:
             verifier.verify()
@@ -260,11 +271,13 @@ class HTTPPostSignatureVerifierTestCase(unittest.TestCase):
         saml_request = self.saml_request.format(
             break_digest='broken',
             signature_value=self.signature_value,
-            signed_info=self.signed_info.format(sig_alg=self.sig_alg, break_signature=''),
+            signed_info=self.signed_info.format(
+                sig_alg=self.sig_alg, break_signature=''),
             certificate=self.cert,
         )
         relay_state = 'relay_state'
-        request = HTTPPostRequest(saml_request=saml_request, relay_state=relay_state)
+        request = HTTPPostRequest(
+            saml_request=saml_request, relay_state=relay_state)
         verifier = HTTPPostSignatureVerifier(self.cert, request)
         with pytest.raises(SignatureVerificationError) as excinfo:
             verifier.verify()
@@ -275,11 +288,13 @@ class HTTPPostSignatureVerifierTestCase(unittest.TestCase):
         saml_request = self.saml_request.format(
             break_digest='',
             signature_value=self.signature_value,
-            signed_info=self.signed_info.format(sig_alg=self.sig_alg, break_signature='broken'),
+            signed_info=self.signed_info.format(
+                sig_alg=self.sig_alg, break_signature='broken'),
             certificate=self.cert,
         )
         relay_state = 'relay_state'
-        request = HTTPPostRequest(saml_request=saml_request, relay_state=relay_state)
+        request = HTTPPostRequest(
+            saml_request=saml_request, relay_state=relay_state)
         verifier = HTTPPostSignatureVerifier(self.cert, request)
         with pytest.raises(SignatureVerificationError) as excinfo:
             verifier.verify()
@@ -293,7 +308,7 @@ class SignedResponseTestCase(unittest.TestCase):
         generate_certificate(fname='test', path=DATA_DIR)
 
     def tearDown(self):
-        to_remove = ['test.key', 'test.crt',]
+        to_remove = ['test.key', 'test.crt', ]
         for f in to_remove:
             os.remove(os.path.join(DATA_DIR, f))
 
@@ -353,11 +368,13 @@ class SignedResponseTestCase(unittest.TestCase):
             )
             decoded_response = b64decode(response)
             tree = etree.fromstring(decoded_response)
-            signature_values = tree.findall('.//{http://www.w3.org/2000/09/xmldsig#}SignatureValue')
-            digest_values = tree.findall('.//{http://www.w3.org/2000/09/xmldsig#}DigestValue')
+            signature_values = tree.findall(
+                './/{http://www.w3.org/2000/09/xmldsig#}SignatureValue')
+            digest_values = tree.findall(
+                './/{http://www.w3.org/2000/09/xmldsig#}DigestValue')
             self.assertEqual(len(signature_values), 0)
             self.assertEqual(len(digest_values), 0)
-            with pytest.raises(InvalidInput) as excinfo:
+            with pytest.raises(InvalidInput) as excinfo:  # noqa: F841
                 XMLVerifier().verify(tree, x509_cert=cert)
             # Signed response
             response = sign_http_post(
@@ -369,8 +386,10 @@ class SignedResponseTestCase(unittest.TestCase):
             )
             decoded_response = b64decode(response)
             tree = etree.fromstring(decoded_response)
-            signature_values = tree.findall('.//{http://www.w3.org/2000/09/xmldsig#}SignatureValue')
-            digest_values = tree.findall('.//{http://www.w3.org/2000/09/xmldsig#}DigestValue')
+            signature_values = tree.findall(
+                './/{http://www.w3.org/2000/09/xmldsig#}SignatureValue')
+            digest_values = tree.findall(
+                './/{http://www.w3.org/2000/09/xmldsig#}DigestValue')
             self.assertEqual(len(signature_values), 1)
             self.assertEqual(len(digest_values), 1)
             XMLVerifier().verify(tree, x509_cert=cert)
@@ -384,8 +403,10 @@ class SignedResponseTestCase(unittest.TestCase):
             )
             decoded_response = b64decode(response)
             tree = etree.fromstring(decoded_response)
-            signature_values = tree.findall('.//{http://www.w3.org/2000/09/xmldsig#}SignatureValue')
-            digest_values = tree.findall('.//{http://www.w3.org/2000/09/xmldsig#}DigestValue')
+            signature_values = tree.findall(
+                './/{http://www.w3.org/2000/09/xmldsig#}SignatureValue')
+            digest_values = tree.findall(
+                './/{http://www.w3.org/2000/09/xmldsig#}DigestValue')
             self.assertEqual(len(signature_values), 1)
             self.assertEqual(len(digest_values), 1)
             XMLVerifier().verify(tree, x509_cert=cert)
@@ -399,8 +420,10 @@ class SignedResponseTestCase(unittest.TestCase):
             )
             decoded_response = b64decode(response)
             tree = etree.fromstring(decoded_response)
-            signature_values = tree.findall('.//{http://www.w3.org/2000/09/xmldsig#}SignatureValue')
-            digest_values = tree.findall('.//{http://www.w3.org/2000/09/xmldsig#}DigestValue')
+            signature_values = tree.findall(
+                './/{http://www.w3.org/2000/09/xmldsig#}SignatureValue')
+            digest_values = tree.findall(
+                './/{http://www.w3.org/2000/09/xmldsig#}DigestValue')
             self.assertEqual(len(signature_values), 2)
             self.assertEqual(len(digest_values), 2)
             XMLVerifier().verify(tree, x509_cert=cert)
@@ -485,7 +508,8 @@ class SignedResponseTestCase(unittest.TestCase):
             ])
             signed_data = signed_data.encode('ascii')
             verified = verifier.verify(
-                load_pem_x509_certificate(cert, backend=default_backend()).public_key(),
+                load_pem_x509_certificate(
+                    cert, backend=default_backend()).public_key(),
                 bytes(signed_data),
                 bytes(signature)
             )
@@ -523,7 +547,8 @@ class SignedResponseTestCase(unittest.TestCase):
             ])
             signed_data = signed_data.encode('ascii')
             verified = verifier.verify(
-                load_pem_x509_certificate(cert, backend=default_backend()).public_key(),
+                load_pem_x509_certificate(
+                    cert, backend=default_backend()).public_key(),
                 bytes(signed_data),
                 bytes(signature)
             )
@@ -563,7 +588,8 @@ class SignedResponseTestCase(unittest.TestCase):
             ])
             signed_data = signed_data.encode('ascii')
             verified = verifier.verify(
-                load_pem_x509_certificate(cert, backend=default_backend()).public_key(),
+                load_pem_x509_certificate(
+                    cert, backend=default_backend()).public_key(),
                 bytes(signed_data),
                 bytes(signature)
             )

--- a/testenv/tests/test_parsers.py
+++ b/testenv/tests/test_parsers.py
@@ -23,17 +23,20 @@ except ImportError:
 
 
 class FakeSAMLClass(object):
+
     def __init__(self, data):
         self.data = data
 
 
 class SuccessValidator(object):
+
     @staticmethod
     def validate(request):
         return None
 
 
 class FailValidator(object):
+
     def __init__(self, exc):
         self._exc = exc
 
@@ -104,6 +107,7 @@ class HTTPRedirectRequestParserTestCase(unittest.TestCase):
 
 
 class HTTPPostRequestParserTestCase(unittest.TestCase):
+
     def setUp(self):
         saml_request = base64.b64encode(b'saml_request').decode('ascii')
         relay_state = 'relay_state'
@@ -195,6 +199,7 @@ class HTTPRequestDeserializerTestCase(unittest.TestCase):
 
 
 class SAMLTreeTestCase(unittest.TestCase):
+
     def test_deserialization(self):
         xml = """\
 <root>
@@ -212,5 +217,7 @@ class SAMLTreeTestCase(unittest.TestCase):
         self.assertEqual(saml_tree.child2.an_attribute, 'more data')
         self.assertEqual(len(saml_tree.special_child3.item), 2)
         self.assertEqual(saml_tree.special_child3.tag, 'special_child3')
-        self.assertEqual(saml_tree.special_child3.item[0].another_attribute, 'foo')
-        self.assertEqual(saml_tree.special_child3.item[1].even_another_attribute, 'bar')
+        self.assertEqual(saml_tree.special_child3.item[
+                         0].another_attribute, 'foo')
+        self.assertEqual(saml_tree.special_child3.item[
+                         1].even_another_attribute, 'bar')

--- a/testenv/tests/test_saml.py
+++ b/testenv/tests/test_saml.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 
 import unittest
 
-from lxml import etree
-
 from testenv.saml import create_idp_metadata, create_response
 from testenv.settings import (
     BINDING_HTTP_POST, BINDING_HTTP_REDIRECT, DS, MD, SAML, SAMLP, SPID_LEVEL_1, STATUS_SUCCESS,
@@ -55,7 +53,8 @@ class SamlElementTestCase(unittest.TestCase):
             },
             {}
         )
-        authenticating_authorities = response._element.findall('.//{%s}AuthenticatingAuthority' % SAML)
+        authenticating_authorities = response._element.findall(
+            './/{%s}AuthenticatingAuthority' % SAML)
         self.assertEqual(len(authenticating_authorities), 0)
 
     def test_issuer_in_response_and_assertion(self):
@@ -100,7 +99,8 @@ class SamlElementTestCase(unittest.TestCase):
         issuers = response._element.findall('.//{%s}Issuer' % SAML)
         self.assertEqual(len(issuers), 2)
         for issuer in issuers:
-            self.assertEqual(issuer.get('NameQualifier'), 'http://test_id.entity')
+            self.assertEqual(issuer.get('NameQualifier'),
+                             'http://test_id.entity')
             self.assertEqual(issuer.text, 'http://test_id.entity')
         self.assertEqual(issuers[0].getparent().tag, '{%s}Response' % SAMLP)
         self.assertEqual(issuers[1].getparent().tag, '{%s}Assertion' % SAML)
@@ -147,7 +147,8 @@ class SamlElementTestCase(unittest.TestCase):
             },
             {}
         )
-        authn_statements = response._element.findall('.//{%s}AuthnStatement' % SAML)
+        authn_statements = response._element.findall(
+            './/{%s}AuthnStatement' % SAML)
         self.assertEqual(len(authn_statements), 1)
         authn_statement = authn_statements[0]
         self.assertTrue(authn_statement.get('SessionIndex', False))

--- a/testenv/tests/test_spid_testenv.py
+++ b/testenv/tests/test_spid_testenv.py
@@ -51,14 +51,20 @@ def generate_authn_request(data={}, acs_level=0, sign=False):
     destination = data.get('destination', 'http://spid-testenv:8088')
     protocol_binding = data.get('protocol_binding', BINDING_HTTP_POST)
     acsi = data.get('assertion_consumer_service_index', '1')
-    acsu = data.get('assertion_consumer_service_url', 'http://127.0.0.1:8000/acs-test')
+    acsu = data.get('assertion_consumer_service_url',
+                    'http://127.0.0.1:8000/acs-test')
     issuer__format = data.get('issuer__format', NAMEID_FORMAT_ENTITY)
     issuer_url = data.get('issuer__url', 'https://spid.test:8000')
     issuer__namequalifier = data.get('issuer__namequalifier', issuer_url)
-    name_id_policy__format = data.get('name_id_policy__format', NAMEID_FORMAT_TRANSIENT)
-    requested_authn_context__comparison = data.get('requested_authn_context__comparison', 'exact')
-    requested_authn_context__authn_context_class_ref = data.get('requested_authn_context__authn_context_class_ref', 'https://www.spid.gov.it/SpidL1')
-    attribute_consuming_service_index = data.get('attribute_consuming_service_index', '')
+    name_id_policy__format = data.get(
+        'name_id_policy__format', NAMEID_FORMAT_TRANSIENT)
+    requested_authn_context__comparison = data.get(
+        'requested_authn_context__comparison', 'exact')
+    requested_authn_context__authn_context_class_ref = data.get(
+        'requested_authn_context__authn_context_class_ref',
+        'https://www.spid.gov.it/SpidL1')
+    attribute_consuming_service_index = data.get(
+        'attribute_consuming_service_index', '')
 
     if acs_level == 0:
         _acs = '''
@@ -68,13 +74,13 @@ def generate_authn_request(data={}, acs_level=0, sign=False):
     elif acs_level == 1:
         _acs = '''
             AssertionConsumerServiceIndex="%s"
-        '''  % (acsi)
+        ''' % (acsi)
     elif acs_level == 2:
         _acs = '''
             ProtocolBinding="%s"
             AssertionConsumerServiceURL="%s"
             AssertionConsumerServiceIndex="%s"
-        '''  % (protocol_binding, acsu, acsi)
+        ''' % (protocol_binding, acsu, acsi)
     else:
         _acs = ''
 
@@ -146,17 +152,26 @@ def generate_authn_request(data={}, acs_level=0, sign=False):
 def generate_logout_request(data={}):
     _id = data.get('id') if data.get('id') else 'test_123456'
     version = data.get('version') if data.get('version') else '2.0'
-    issue_instant = data.get('issue_instant') if data.get('issue_instant') else '2018-07-16T09:38:29Z'
-    destination = data.get('destination') if data.get('destination') else 'http://spid-testenv:8088'
-    issuer__format = data.get('issuer__format') if data.get('issuer__format') else NAMEID_FORMAT_ENTITY
-    issuer_url = data.get('issuer__url') if data.get('issuer__url') else 'https://spid.test:8000'
-    issuer__namequalifier = data.get('issuer__namequalifier') if data.get('issuer__namequalifier') else issuer_url
-    name_id__format = data.get('name_id__format') if data.get('name_id__format') else NAMEID_FORMAT_TRANSIENT
-    name_id__namequalifier = data.get('name_id__namequalifier') if data.get('name_id__namequalifier') else 'https://spid.test:8000'
-    name_id__value = data.get('name_id__value') if data.get('name_id__value') else 'name_id'
-    session_index__value = data.get('session_index__value') if data.get('session_index__value') else 'session_idx_123'
+    issue_instant = data.get('issue_instant') if data.get(
+        'issue_instant') else '2018-07-16T09:38:29Z'
+    destination = data.get('destination') if data.get(
+        'destination') else 'http://spid-testenv:8088'
+    issuer__format = data.get('issuer__format') if data.get(
+        'issuer__format') else NAMEID_FORMAT_ENTITY
+    issuer_url = data.get('issuer__url') if data.get(
+        'issuer__url') else 'https://spid.test:8000'
+    issuer__namequalifier = data.get('issuer__namequalifier') if data.get(
+        'issuer__namequalifier') else issuer_url
+    name_id__format = data.get('name_id__format') if data.get(
+        'name_id__format') else NAMEID_FORMAT_TRANSIENT
+    name_id__namequalifier = data.get('name_id__namequalifier') if data.get(
+        'name_id__namequalifier') else 'https://spid.test:8000'
+    name_id__value = data.get('name_id__value') if data.get(
+        'name_id__value') else 'name_id'
+    session_index__value = data.get('session_index__value') if data.get(
+        'session_index__value') else 'session_idx_123'
 
-    xmlstr= '''<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlstr = '''<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
                 xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
                 ID="%s"
                 Version="%s"
@@ -200,7 +215,8 @@ class SpidTestenvTest(unittest.TestCase):
         xml = ET.parse(tmp_metadata)
         with open(sp_cert, 'r') as f:
             cert_value = ''.join(f.readlines()[1:-1])
-            for cert in xml.findall('//{http://www.w3.org/2000/09/xmldsig#}X509Certificate'):
+            for cert in xml.findall(
+                    '//{http://www.w3.org/2000/09/xmldsig#}X509Certificate'):
                 cert.text = cert_value
         xml.write(tmp_metadata)
         app = flask.Flask(spid_testenv.__name__, static_url_path='/static')
@@ -212,7 +228,8 @@ class SpidTestenvTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        to_remove = ['users.json', 'idp.crt', 'idp.key', 'sp.crt', 'sp.key', 'sp-metadata.xml']
+        to_remove = ['users.json', 'idp.crt', 'idp.key',
+                     'sp.crt', 'sp.key', 'sp-metadata.xml']
         for f in to_remove:
             os.remove(os.path.join(DATA_DIR, f))
 
@@ -229,7 +246,8 @@ class SpidTestenvTest(unittest.TestCase):
         self.assertEqual(response.status_code, 403)
         response = self.test_client.post('/continue-response')
         self.assertEqual(response.status_code, 400)
-        response = self.test_client.post('/continue-response', data={'request_key': 'somevalue'})
+        response = self.test_client.post(
+            '/continue-response', data={'request_key': 'somevalue'})
         self.assertEqual(response.status_code, 403)
         response = self.test_client.get('/users')
         self.assertEqual(response.status_code, 200)
@@ -241,73 +259,80 @@ class SpidTestenvTest(unittest.TestCase):
     def test_authnrequest_no_SAML_parameter(self):
         response = self.test_client.get('/sso-test')
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'Dato mancante nella request: &#39;SAMLRequest&#39;', response.get_data())
+        self.assertIn(
+            b'Dato mancante nella request: &#39;SAMLRequest&#39;',
+            response.get_data())
 
     @freeze_time("2018-07-16T10:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request())
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_authn_request())
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_issue_instant_out_of_range(self, unravel, verified):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response_text = response.get_data(as_text=True)
         self.assertIn(
             '2018-07-16 09:38:29 non è compreso tra 2018-07-16 10:36:29 e 2018-07-16 10:40:29',
-            response_text
-        )
+            response_text)
         self.assertNotIn(
             'la data non è in formato UTC',
             response_text
         )
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request())
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_authn_request())
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_issue_instant_ok(self, unravel, verified):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response_text = response.get_data(as_text=True)
         self.assertNotIn(
             '2018-07-16 09:38:29 non è compreso tra 2018-07-16 09:36:29 e 2018-07-16 09:40:29',
-            response_text
-        )
+            response_text)
         self.assertNotIn(
             'la data non è in formato UTC',
             response_text
         )
 
     @freeze_time("2018-07-11T07:28:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request({'issue_instant': '2018-07-11T07:28:57.935Z'}))
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_authn_request({'issue_instant': '2018-07-11T07:28:57.935Z'}))
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_issue_instant_ms(self, unravel, verified):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response_text = response.get_data(as_text=True)
         self.assertNotIn(
             '2018-07-16 09:38:29 non è compreso tra 2018-07-16 09:36:29 e 2018-07-16 09:40:29',
-            response_text
-        )
+            response_text)
         self.assertNotIn(
             'la data non è in formato UTC',
             response_text
         )
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request({'protocol_binding': BINDING_HTTP_REDIRECT}))
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_authn_request({'protocol_binding': BINDING_HTTP_REDIRECT}))
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_wrong_protocol_binding(self, unravel, verified):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response_text = response.get_data(as_text=True)
         self.assertIn(
@@ -316,42 +341,50 @@ class SpidTestenvTest(unittest.TestCase):
         )
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request({'protocol_binding': BINDING_HTTP_POST}))
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_authn_request({'protocol_binding': BINDING_HTTP_POST}))
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_right_protocol_binding(self, unravel, verified):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response_text = response.get_data(as_text=True)
         self.assertNotIn(
-            '{} è diverso dal valore di riferimento {}'.format(BINDING_HTTP_REDIRECT, BINDING_HTTP_POST),
+            '{} è diverso dal valore di riferimento {}'.format(
+                BINDING_HTTP_REDIRECT, BINDING_HTTP_POST),
             response_text
         )
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request())
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_authn_request())
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_no_assertion_consumer_service_index(self, unravel, verified):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response_text = response.get_data(as_text=True)
         self.assertNotIn(
-            'Uno e uno solo uno tra gli attributi o gruppi di attributi devono essere presenti: [AssertionConsumerServiceIndex, [AssertionConsumerServiceUrl, ProtocolBinding]]',            response_text
-        )
+            'Uno e uno solo uno tra gli attributi o gruppi di attributi devono essere presenti: [AssertionConsumerServiceIndex, [AssertionConsumerServiceUrl, ProtocolBinding]]',
+            response_text)
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request(acs_level=1))
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
-    def test_no_assertion_consumer_service_url_and_protocol_binding(self, unravel, verified):
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_authn_request(acs_level=1))
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
+    def test_no_assertion_consumer_service_url_and_protocol_binding(
+            self, unravel, verified):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response_text = response.get_data(as_text=True)
         self.assertNotIn(
@@ -360,13 +393,16 @@ class SpidTestenvTest(unittest.TestCase):
         )
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request(acs_level=2))
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
-    def test_all_assertion_consumer_service_attributes(self, unravel, verified):
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_authn_request(acs_level=2))
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
+    def test_all_assertion_consumer_service_attributes(
+            self, unravel, verified):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response_text = response.get_data(as_text=True)
         self.assertIn(
@@ -375,13 +411,15 @@ class SpidTestenvTest(unittest.TestCase):
         )
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request(acs_level=3))
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_authn_request(acs_level=3))
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_no_assertion_consumer_service_attributes(self, unravel, verified):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response_text = response.get_data(as_text=True)
         self.assertIn(
@@ -390,27 +428,30 @@ class SpidTestenvTest(unittest.TestCase):
         )
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request())
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_authn_request())
     def test_wrong_signature_algorithm(self, unravel):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA1)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA1)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response_text = response.get_data(as_text=True)
         self.assertIn(
-            "L&#39;algoritmo &#39;{}&#39; è considerato deprecato.".format(SIG_RSA_SHA1),
+            "L&#39;algoritmo &#39;{}&#39; è considerato deprecato.".format(
+                SIG_RSA_SHA1),
             response_text
         )
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request())
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_authn_request())
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_right_signature_algorithm(self, unravel, verified):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response_text = response.get_data(as_text=True)
         self.assertNotIn(
@@ -419,15 +460,17 @@ class SpidTestenvTest(unittest.TestCase):
         )
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request())
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_authn_request())
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_in_response_to(self, unravel, verified):
         self.assertEqual(len(self.idp_server.ticket), 0)
         self.assertEqual(len(self.idp_server.responses), 0)
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response = self.test_client.post(
             '/login',
@@ -459,11 +502,10 @@ class SpidTestenvTest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(self.idp_server.ticket), 0)
         self.assertEqual(len(self.idp_server.responses), 0)
-        with patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value = generate_authn_request({'id': 'test_9999'})) as mocked:
+        with patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request({'id': 'test_9999'})) as mocked:  # noqa: F841
             response = self.test_client.get(
-                '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-                follow_redirects=True
-            )
+                '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                    quote(SIG_RSA_SHA256)), follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             response = self.test_client.post(
                 '/login',
@@ -491,28 +533,39 @@ class SpidTestenvTest(unittest.TestCase):
             )
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request(data={'assertion_consumer_service_index': '12345'}, acs_level=1))
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch(
+        'testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+        return_value=generate_authn_request(
+            data={
+                'assertion_consumer_service_index': '12345'},
+            acs_level=1))
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_wrong_assertion_consumer_service_index(self, unravel, verified):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response_text = response.get_data(as_text=True)
         self.assertIn(
             "12345 non corrisponde a nessuno dei valori contenuti in [&#39;0&#39;]",
-            response_text
-        )
+            response_text)
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request(data={'assertion_consumer_service_index': '0'}, acs_level=1))
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch(
+        'testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+        return_value=generate_authn_request(
+            data={
+                'assertion_consumer_service_index': '0'},
+            acs_level=1))
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_right_assertion_consumer_service_index(self, unravel, verified):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         response_text = response.get_data(as_text=True)
         self.assertNotIn(
@@ -521,15 +574,22 @@ class SpidTestenvTest(unittest.TestCase):
         )
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request(data={'assertion_consumer_service_index': '0'}, acs_level=1))
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch(
+        'testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+        return_value=generate_authn_request(
+            data={
+                'assertion_consumer_service_index': '0'},
+            acs_level=1))
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_ensure_correct_redirect_url(self, unravel, verified):
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=False
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=False)
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.headers['Location'], 'http://localhost/login')
+        self.assertEqual(response.headers[
+                         'Location'], 'http://localhost/login')
         response = self.test_client.post(
             '/login',
             data={
@@ -558,8 +618,11 @@ class SpidTestenvTest(unittest.TestCase):
         )
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request())
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_authn_request())
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_missing_samlrequest_parameter(self, unravel, verified):
         self.assertEqual(len(self.idp_server.ticket), 0)
         self.assertEqual(len(self.idp_server.responses), 0)
@@ -583,7 +646,8 @@ class SpidTestenvTest(unittest.TestCase):
         self.assertEqual(len(self.idp_server.ticket), 0)
         self.assertEqual(len(self.idp_server.responses), 0)
         response = self.test_client.get(
-            '/sso-test?SAMLRequest={}&SigAlg={}&Signature=sign'.format(quote(encoded_message), quote(SIG_RSA_SHA256)),
+            '/sso-test?SAMLRequest={}&SigAlg={}&Signature=sign'.format(
+                quote(encoded_message), quote(SIG_RSA_SHA256)),
             follow_redirects=True
         )
         self.assertEqual(response.status_code, 200)
@@ -603,7 +667,8 @@ class SpidTestenvTest(unittest.TestCase):
         self.assertEqual(len(self.idp_server.ticket), 0)
         self.assertEqual(len(self.idp_server.responses), 0)
         response = self.test_client.get(
-            '/sso-test?SAMLRequest={}&SigAlg={}'.format(quote(encoded_message), quote(SIG_RSA_SHA256)),
+            '/sso-test?SAMLRequest={}&SigAlg={}'.format(
+                quote(encoded_message), quote(SIG_RSA_SHA256)),
             follow_redirects=True
         )
         self.assertEqual(response.status_code, 200)
@@ -623,7 +688,8 @@ class SpidTestenvTest(unittest.TestCase):
         self.assertEqual(len(self.idp_server.ticket), 0)
         self.assertEqual(len(self.idp_server.responses), 0)
         response = self.test_client.get(
-            '/sso-test?SAMLRequest={}&Signature={}'.format(quote(encoded_message), quote(SIG_RSA_SHA256)),
+            '/sso-test?SAMLRequest={}&Signature={}'.format(
+                quote(encoded_message), quote(SIG_RSA_SHA256)),
             follow_redirects=True
         )
         self.assertEqual(response.status_code, 200)
@@ -636,14 +702,16 @@ class SpidTestenvTest(unittest.TestCase):
         self.assertEqual(len(self.idp_server.responses), 0)
 
     @freeze_time("2018-07-16T09:38:29Z")
-    def test_authn_request_http_redirect_missing_sigalg_and_signature_parameter(self):
+    def test_authn_request_http_redirect_missing_sigalg_and_signature_parameter(
+            self):
         # See: https://github.com/italia/spid-testenv2/issues/36
         xml_message = generate_authn_request()
         encoded_message = deflate_and_base64_encode(xml_message)
         self.assertEqual(len(self.idp_server.ticket), 0)
         self.assertEqual(len(self.idp_server.responses), 0)
         response = self.test_client.get(
-            '/sso-test?SAMLRequest={}'.format(quote(encoded_message), quote(SIG_RSA_SHA256)),
+            '/sso-test?SAMLRequest={}'.format(quote(encoded_message),
+                                              quote(SIG_RSA_SHA256)),
             follow_redirects=True
         )
         self.assertEqual(response.status_code, 200)
@@ -659,7 +727,8 @@ class SpidTestenvTest(unittest.TestCase):
     def test_authn_request_http_redirect_right_signature(self):
         xml_message = generate_authn_request()
         pkey = open(os.path.join(DATA_DIR, 'sp.key'), 'rb').read()
-        query_string = sign_http_redirect(xml_message, pkey, req_type='SAMLRequest')
+        query_string = sign_http_redirect(
+            xml_message, pkey, req_type='SAMLRequest')
         self.assertEqual(len(self.idp_server.ticket), 0)
         self.assertEqual(len(self.idp_server.responses), 0)
         response = self.test_client.get(
@@ -670,8 +739,7 @@ class SpidTestenvTest(unittest.TestCase):
         response_text = response.get_data(as_text=True)
         self.assertIn(
             '<form class="Form Form--spaced u-margin-bottom-l " name="login" method="post" action="/login">',
-            response_text
-        )
+            response_text)
         self.assertEqual(len(self.idp_server.ticket), 1)
         self.assertEqual(len(self.idp_server.responses), 0)
         key = list(self.idp_server.ticket.keys())[0]
@@ -681,14 +749,20 @@ class SpidTestenvTest(unittest.TestCase):
         self.assertEqual(xml_message.id, xmlstr.id)
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request(data={'issuer__url': 'https://something.spid.test'}, acs_level=1))
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch(
+        'testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+        return_value=generate_authn_request(
+            data={
+                'issuer__url': 'https://something.spid.test'},
+            acs_level=1))
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_wrong_issuer(self, unravel, verified):
         # See: https://github.com/italia/spid-testenv2/issues/42
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(self.idp_server.ticket), 0)
         self.assertEqual(len(self.idp_server.responses), 0)
@@ -699,33 +773,40 @@ class SpidTestenvTest(unittest.TestCase):
         )
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request(data={'issuer__namequalifier': 'https://something.spid.test'}, acs_level=1))
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch(
+        'testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+        return_value=generate_authn_request(
+            data={
+                'issuer__namequalifier': 'https://something.spid.test'},
+            acs_level=1))
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_wrong_issuer_namequalifier(self, unravel, verified):
         # See: https://github.com/italia/spid-testenv2/issues/77
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(self.idp_server.ticket), 0)
         self.assertEqual(len(self.idp_server.responses), 0)
         response_text = response.get_data(as_text=True)
         self.assertIn(
             'https://something.spid.test è diverso dal valore di riferimento https://spid.test:8000',
-            response_text
-        )
+            response_text)
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_logout_request())
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_logout_request())
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_logout_response_http_redirect(self, unravel, verified):
         # See: https://github.com/italia/spid-testenv2/issues/88
-        with patch('testenv.server.IdpServer._sp_single_logout_service', return_value=_sp_single_logout_service(self.idp_server, 'https://spid.test:8000', BINDING_HTTP_REDIRECT)) as mocked:
+        with patch('testenv.server.IdpServer._sp_single_logout_service', return_value=_sp_single_logout_service(self.idp_server, 'https://spid.test:8000', BINDING_HTTP_REDIRECT)) as mocked:  # noqa: F841
             response = self.test_client.get(
-                '/slo-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-                follow_redirects=False
-            )
+                '/slo-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                    quote(SIG_RSA_SHA256)), follow_redirects=False)
             self.assertEqual(response.status_code, 302)
             response_location = response.headers.get('Location')
             url = urlparse(response_location)
@@ -737,34 +818,40 @@ class SpidTestenvTest(unittest.TestCase):
             saml_response = query.get('SAMLResponse')[0]
             response = decode_base64_and_inflate(saml_response)
             xml = ET.fromstring(response)
-            signatures = xml.findall('.//{http://www.w3.org/2000/09/xmldsig#}Signature')
+            signatures = xml.findall(
+                './/{http://www.w3.org/2000/09/xmldsig#}Signature')
             self.assertEqual(0, len(signatures))
             self.assertEqual(len(self.idp_server.ticket), 0)
             self.assertEqual(len(self.idp_server.responses), 0)
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_logout_request())
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+           return_value=generate_logout_request())
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_logout_response_http_post(self, unravel, verified):
         # See: https://github.com/italia/spid-testenv2/issues/88
-        with patch('testenv.server.IdpServer._sp_single_logout_service', return_value=_sp_single_logout_service(self.idp_server, 'https://spid.test:8000', BINDING_HTTP_POST)) as mocked:
+        with patch('testenv.server.IdpServer._sp_single_logout_service', return_value=_sp_single_logout_service(self.idp_server, 'https://spid.test:8000', BINDING_HTTP_POST)) as mocked:  # noqa: F841
             response = self.test_client.get(
-                '/slo-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-                follow_redirects=False
-            )
+                '/slo-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                    quote(SIG_RSA_SHA256)), follow_redirects=False)
             self.assertEqual(response.status_code, 200)
             response_text = response.get_data(as_text=True)
             soup = BS(response_text)
-            saml_response = soup.find('input', {'name': 'SAMLResponse'}).get('value')
+            saml_response = soup.find(
+                'input', {'name': 'SAMLResponse'}).get('value')
             response = base64.b64decode(saml_response)
             xml = ET.fromstring(response)
-            signatures = xml.findall('.//{http://www.w3.org/2000/09/xmldsig#}Signature')
+            signatures = xml.findall(
+                './/{http://www.w3.org/2000/09/xmldsig#}Signature')
             self.assertEqual(1, len(signatures))
             self.assertEqual(len(self.idp_server.ticket), 0)
             self.assertEqual(len(self.idp_server.responses), 0)
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPPostRequestParser._decode_saml_request', return_value=generate_authn_request(sign=True))
+    @patch('testenv.parser.HTTPPostRequestParser._decode_saml_request',
+           return_value=generate_authn_request(sign=True))
     @patch('testenv.crypto.HTTPPostSignatureVerifier.verify', return_value=True)
     def test_relaystate_in_post_request_to_sp(self, verified, unravel):
         # https://github.com/italia/spid-testenv2/issues/135
@@ -799,7 +886,7 @@ class SpidTestenvTest(unittest.TestCase):
 
     def test_fiscal_number_prefix(self):
         # https://github.com/italia/spid-testenv2/issues/150
-        response = self.test_client.post(
+        self.test_client.post(
             '/users',
             data={
                 'username': 'testusr',
@@ -811,31 +898,42 @@ class SpidTestenvTest(unittest.TestCase):
         )
         users = self.idp_server.user_manager.all()
         self.assertIn('testusr', users)
-        fiscal_number = users['testusr'].get('attrs', {}).get('fiscalNumber', {})
+        fiscal_number = users['testusr'].get(
+            'attrs', {}).get('fiscalNumber', {})
         self.assertTrue(fiscal_number.startswith('TINIT-'))
         self.assertEqual(fiscal_number, 'TINIT-abc123')
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request(data={'assertion_consumer_service_url': 'someacs'}))
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch(
+        'testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+        return_value=generate_authn_request(
+            data={
+                'assertion_consumer_service_url': 'someacs'}))
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_wrong_assertion_consumer_service_url(self, unravel, verified):
         # See: https://github.com/italia/spid-testenv2/issues/122
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(self.idp_server.ticket), 0)
         self.assertEqual(len(self.idp_server.responses), 0)
         response_text = response.get_data(as_text=True)
         self.assertIn(
             'someacs è diverso dal valore di riferimento [&#39;http://127.0.0.1:8000/acs-test&#39;]',
-            response_text
-        )
+            response_text)
 
     @freeze_time("2018-07-16T09:38:29Z")
-    @patch('testenv.parser.HTTPRedirectRequestParser._decode_saml_request', return_value=generate_authn_request(data={'attribute_consuming_service_index': 1}))
-    @patch('testenv.crypto.HTTPRedirectSignatureVerifier.verify', return_value=True)
+    @patch(
+        'testenv.parser.HTTPRedirectRequestParser._decode_saml_request',
+        return_value=generate_authn_request(
+            data={
+                'attribute_consuming_service_index': 1}))
+    @patch(
+        'testenv.crypto.HTTPRedirectSignatureVerifier.verify',
+        return_value=True)
     def test_user_without_some_requested_attribute(self, verified, unravel):
         # https://github.com/italia/spid-testenv2/issues/164
         # https://github.com/italia/spid-testenv2/issues/144
@@ -845,9 +943,8 @@ class SpidTestenvTest(unittest.TestCase):
             }
         )
         response = self.test_client.get(
-            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(quote(SIG_RSA_SHA256)),
-            follow_redirects=True
-        )
+            '/sso-test?SAMLRequest=b64encodedrequest&SigAlg={}&Signature=sign'.format(
+                quote(SIG_RSA_SHA256)), follow_redirects=True)
         response = self.test_client.post(
             '/login',
             data={
@@ -868,6 +965,7 @@ class SpidTestenvTest(unittest.TestCase):
             },
             follow_redirects=False
         )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/testenv/tests/test_validators.py
+++ b/testenv/tests/test_validators.py
@@ -22,6 +22,7 @@ class FakeTranslator(object):
 
 
 class FakeConfig(object):
+
     def __init__(self, endpoint, entity_id):
         self._endpoint = endpoint
         self._entity_id = entity_id
@@ -35,6 +36,7 @@ class FakeConfig(object):
 
 
 class FakeMetadata(dict):
+
     def __init__(self, service_providers, assertion_consumer_services):
         self._service_providers = service_providers
         self._assertion_consumer_services = assertion_consumer_services
@@ -47,6 +49,7 @@ class FakeMetadata(dict):
 
 
 class FakeRegistry(object):
+
     def __init__(self, metadata):
         self._metadata = metadata.copy()
 
@@ -64,11 +67,10 @@ class ServiceProviderMetadataFakeLoader(object):
         self.atcs_indexes = atcs_indexes
         self.acs_indexes = acs_indexes
 
-
     @property
     def attribute_consuming_services(self):
         return [
-            { 'attrs': { 'index': index }} for index in self.atcs_indexes
+            {'attrs': {'index': index}} for index in self.atcs_indexes
         ]
 
     @property
@@ -216,7 +218,8 @@ class SPIDValidatorTestCase(unittest.TestCase):
     @freeze_time('2018-08-18T06:55:22Z')
     def test_missing_issuer(self):
         # https://github.com/italia/spid-testenv2/issues/133
-        config = FakeConfig('http://localhost:8088/sso', 'http://localhost:8088/')
+        config = FakeConfig('http://localhost:8088/sso',
+                            'http://localhost:8088/')
         registry = FakeRegistry({
             'http://localhost:8088/': ServiceProviderMetadataFakeLoader([], [(0, 'http://localhost:3000/spid-sso')])
         })
@@ -227,12 +230,14 @@ class SPIDValidatorTestCase(unittest.TestCase):
                 request.saml_request = request.saml_request % (val)
                 validator.validate(request)
             exc = excinfo.value
-            self.assertEqual('Issuer non presente nella AuthnRequest', str(exc))
+            self.assertEqual(
+                'Issuer non presente nella AuthnRequest', str(exc))
 
     @freeze_time('2018-08-18T06:55:22Z')
     def test_wrong_destination(self):
         # https://github.com/italia/spid-testenv2/issues/158
-        config = FakeConfig('http://localhost:9999/sso', 'http://localhost:9999/')
+        config = FakeConfig('http://localhost:9999/sso',
+                            'http://localhost:9999/')
         registry = FakeRegistry({
             'https://localhost:8088/': ServiceProviderMetadataFakeLoader([], [(0, 'http://localhost:3000/spid-sso')])
         })
@@ -246,18 +251,21 @@ class SPIDValidatorTestCase(unittest.TestCase):
                 request.saml_request = request.saml_request % (val)
                 validator.validate(request)
             exc = excinfo.value
-            self.assertEqual('è diverso dal valore di riferimento http://localhost:9999/', exc.details[0].message)
+            self.assertEqual(
+                'è diverso dal valore di riferimento http://localhost:9999/', exc.details[0].message)
 
     @freeze_time('2018-08-18T06:55:22Z')
     def test_authn_request_http_post_without_signature(self):
         # https://github.com/italia/spid-testenv2/issues/159
         # https://github.com/italia/spid-testenv2/issues/165
-        config = FakeConfig('http://localhost:8088/sso', 'http://localhost:8088/')
+        config = FakeConfig('http://localhost:8088/sso',
+                            'http://localhost:8088/')
         request = FakeRequest(sample_requests.auth_no_signature % (''))
         registry = FakeRegistry({
             'https://localhost:8088/': ServiceProviderMetadataFakeLoader([], [(0, 'http://localhost:3000/spid-sso')])
         })
-        validator = SpidValidator('login', settings.BINDING_HTTP_POST, registry, config)
+        validator = SpidValidator(
+            'login', settings.BINDING_HTTP_POST, registry, config)
         with pytest.raises(SPIDValidationError) as excinfo:
             validator.validate(request)
         exc = excinfo.value
@@ -271,24 +279,30 @@ class SPIDValidatorTestCase(unittest.TestCase):
     def test_authn_request_http_post_with_signature(self):
         # https://github.com/italia/spid-testenv2/issues/159
         # https://github.com/italia/spid-testenv2/issues/165
-        config = FakeConfig('http://localhost:8088/sso', 'http://localhost:8088/')
-        request = FakeRequest(sample_requests.auth_no_signature % (sample_requests.fake_signature))
+        config = FakeConfig('http://localhost:8088/sso',
+                            'http://localhost:8088/')
+        request = FakeRequest(sample_requests.auth_no_signature %
+                              (sample_requests.fake_signature))
         registry = FakeRegistry({
             'https://localhost:8088/': ServiceProviderMetadataFakeLoader([], [(0, 'http://localhost:3000/spid-sso')])
         })
-        validator = SpidValidator('login', settings.BINDING_HTTP_POST, registry, config)
+        validator = SpidValidator(
+            'login', settings.BINDING_HTTP_POST, registry, config)
         validator.validate(request)
 
     @freeze_time('2018-08-18T06:55:22Z')
     def test_authn_request_http_redirect_with_signature(self):
         # https://github.com/italia/spid-testenv2/issues/159
         # https://github.com/italia/spid-testenv2/issues/165
-        config = FakeConfig('http://localhost:8088/sso', 'http://localhost:8088/')
-        request = FakeRequest(sample_requests.auth_no_signature % (sample_requests.fake_signature))
+        config = FakeConfig('http://localhost:8088/sso',
+                            'http://localhost:8088/')
+        request = FakeRequest(sample_requests.auth_no_signature %
+                              (sample_requests.fake_signature))
         registry = FakeRegistry({
             'https://localhost:8088/': ServiceProviderMetadataFakeLoader([], [(0, 'http://localhost:3000/spid-sso')])
         })
-        validator = SpidValidator('login', settings.BINDING_HTTP_REDIRECT, registry, config)
+        validator = SpidValidator(
+            'login', settings.BINDING_HTTP_REDIRECT, registry, config)
         with pytest.raises(SPIDValidationError) as excinfo:
             validator.validate(request)
         exc = excinfo.value
@@ -302,24 +316,28 @@ class SPIDValidatorTestCase(unittest.TestCase):
     def test_authn_request_http_redirect_without_signature(self):
         # https://github.com/italia/spid-testenv2/issues/159
         # https://github.com/italia/spid-testenv2/issues/165
-        config = FakeConfig('http://localhost:8088/sso', 'http://localhost:8088/')
+        config = FakeConfig('http://localhost:8088/sso',
+                            'http://localhost:8088/')
         request = FakeRequest(sample_requests.auth_no_signature % (''))
         registry = FakeRegistry({
             'https://localhost:8088/': ServiceProviderMetadataFakeLoader([], [(0, 'http://localhost:3000/spid-sso')])
         })
-        validator = SpidValidator('login', settings.BINDING_HTTP_REDIRECT, registry, config)
+        validator = SpidValidator(
+            'login', settings.BINDING_HTTP_REDIRECT, registry, config)
         validator.validate(request)
 
     @freeze_time('2018-08-18T06:55:22Z')
     def test_logout_request_http_post_without_signature(self):
         # https://github.com/italia/spid-testenv2/issues/159
         # https://github.com/italia/spid-testenv2/issues/165
-        config = FakeConfig('http://localhost:8088/sso', 'http://localhost:8088/')
+        config = FakeConfig('http://localhost:8088/sso',
+                            'http://localhost:8088/')
         request = FakeRequest(sample_requests.logout_no_signature % (''))
         registry = FakeRegistry({
             'https://localhost:8088/': ServiceProviderMetadataFakeLoader([], [(0, 'http://localhost:3000/spid-sso')])
         })
-        validator = SpidValidator('logout', settings.BINDING_HTTP_POST, registry, config)
+        validator = SpidValidator(
+            'logout', settings.BINDING_HTTP_POST, registry, config)
         with pytest.raises(SPIDValidationError) as excinfo:
             validator.validate(request)
         exc = excinfo.value
@@ -333,24 +351,30 @@ class SPIDValidatorTestCase(unittest.TestCase):
     def test_logout_request_http_post_with_signature(self):
         # https://github.com/italia/spid-testenv2/issues/159
         # https://github.com/italia/spid-testenv2/issues/165
-        config = FakeConfig('http://localhost:8088/sso', 'http://localhost:8088/')
-        request = FakeRequest(sample_requests.logout_no_signature % (sample_requests.fake_signature))
+        config = FakeConfig('http://localhost:8088/sso',
+                            'http://localhost:8088/')
+        request = FakeRequest(sample_requests.logout_no_signature %
+                              (sample_requests.fake_signature))
         registry = FakeRegistry({
             'https://localhost:8088/': ServiceProviderMetadataFakeLoader([], [(0, 'http://localhost:3000/spid-sso')])
         })
-        validator = SpidValidator('logout', settings.BINDING_HTTP_POST, registry, config)
+        validator = SpidValidator(
+            'logout', settings.BINDING_HTTP_POST, registry, config)
         validator.validate(request)
 
     @freeze_time('2018-08-18T06:55:22Z')
     def test_logout_request_http_redirect_with_signature(self):
         # https://github.com/italia/spid-testenv2/issues/159
         # https://github.com/italia/spid-testenv2/issues/165
-        config = FakeConfig('http://localhost:8088/sso', 'http://localhost:8088/')
-        request = FakeRequest(sample_requests.logout_no_signature % (sample_requests.fake_signature))
+        config = FakeConfig('http://localhost:8088/sso',
+                            'http://localhost:8088/')
+        request = FakeRequest(sample_requests.logout_no_signature %
+                              (sample_requests.fake_signature))
         registry = FakeRegistry({
             'https://localhost:8088/': ServiceProviderMetadataFakeLoader([], [(0, 'http://localhost:3000/spid-sso')])
         })
-        validator = SpidValidator('logout', settings.BINDING_HTTP_REDIRECT, registry, config)
+        validator = SpidValidator(
+            'logout', settings.BINDING_HTTP_REDIRECT, registry, config)
         with pytest.raises(SPIDValidationError) as excinfo:
             validator.validate(request)
         exc = excinfo.value
@@ -364,10 +388,12 @@ class SPIDValidatorTestCase(unittest.TestCase):
     def test_logout_request_http_redirect_without_signature(self):
         # https://github.com/italia/spid-testenv2/issues/159
         # https://github.com/italia/spid-testenv2/issues/165
-        config = FakeConfig('http://localhost:8088/sso', 'http://localhost:8088/')
+        config = FakeConfig('http://localhost:8088/sso',
+                            'http://localhost:8088/')
         request = FakeRequest(sample_requests.logout_no_signature % (''))
         registry = FakeRegistry({
             'https://localhost:8088/': ServiceProviderMetadataFakeLoader([], [(0, 'http://localhost:3000/spid-sso')])
         })
-        validator = SpidValidator('logout', settings.BINDING_HTTP_REDIRECT, registry, config)
+        validator = SpidValidator(
+            'logout', settings.BINDING_HTTP_REDIRECT, registry, config)
         validator.validate(request)

--- a/testenv/tests/test_xsd_error_translation.py
+++ b/testenv/tests/test_xsd_error_translation.py
@@ -41,15 +41,18 @@ class Libxml2ItalianTranslationTestCase(unittest.TestCase):
         translator = Libxml2Translator()
         for input_data, it_message in self.samples.items():
             domain, type_, en_message = input_data
-            en_error = ValidationDetail(None, 1, 2, domain, type_, en_message, '')
+            en_error = ValidationDetail(
+                None, 1, 2, domain, type_, en_message, '')
             it_error = translator.translate(en_error)
             self.assertEqual(it_error.message, it_message)
 
     def test_multiple_error_translation(self):
         translator = Libxml2Translator()
         errors = [
-            ValidationDetail(None, 1, 2, 'domain1', 'type1', 'an error occured', 'path1'),
-            ValidationDetail(None, 3, 4, 'domain2', 'type2', 'another error occured', 'path2')
+            ValidationDetail(None, 1, 2, 'domain1', 'type1',
+                             'an error occured', 'path1'),
+            ValidationDetail(None, 3, 4, 'domain2', 'type2',
+                             'another error occured', 'path2')
         ]
         actual = translator.translate_many(errors)
         self.assertEqual(actual, errors)

--- a/testenv/users.py
+++ b/testenv/users.py
@@ -21,6 +21,7 @@ class AbstractUserManager(object):
     """
     Base User manager class to handling user objects
     """
+
     def __init__(self, conf=None):
         self._config = conf or config.params
 

--- a/testenv/validators.py
+++ b/testenv/validators.py
@@ -28,6 +28,7 @@ ValidationDetail = namedtuple(
 
 
 class ValidatorGroup(object):
+
     def __init__(self, validators):
         self._validators = validators
         self._validation_errors = []
@@ -96,6 +97,7 @@ class XMLFormatValidator(object):
 
 
 class XMLMetadataFormatValidator(XMLFormatValidator):
+
     def validate(self, xmlstr):
         try:
             etree.fromstring(xmlstr, parser=self._parser)
@@ -175,6 +177,7 @@ class BaseXMLSchemaValidator(object):
 
 
 class AuthnRequestXMLSchemaValidator(BaseXMLSchemaValidator):
+
     def validate(self, request):
         xml = request.saml_request
         schema_type = 'protocol'
@@ -182,6 +185,7 @@ class AuthnRequestXMLSchemaValidator(BaseXMLSchemaValidator):
 
 
 class ServiceProviderMetadataXMLSchemaValidator(BaseXMLSchemaValidator):
+
     def validate(self, metadata):
         schema_type = 'metadata'
         return self._run(metadata, schema_type)
@@ -250,8 +254,10 @@ class SpidValidator(object):
                 ) for el in atcss if 'index' in el.get('attrs', {})
             ]
             ascss = sp_metadata.assertion_consumer_services
-            assertion_consumer_service_indexes = [str(el.get('index')) for el in ascss]
-            assertion_consumer_service_urls = [str(el.get('Location')) for el in ascss]
+            assertion_consumer_service_indexes = [
+                str(el.get('index')) for el in ascss]
+            assertion_consumer_service_urls = [
+                str(el.get('Location')) for el in ascss]
         else:
             attribute_consuming_service_indexes = []
             assertion_consumer_service_indexes = []
@@ -262,11 +268,13 @@ class SpidValidator(object):
             {
                 'attrs': {
                     'Format': Equal(
-                        NAMEID_FORMAT_ENTITY, msg=DEFAULT_VALUE_ERROR.format(NAMEID_FORMAT_ENTITY)
+                        NAMEID_FORMAT_ENTITY, msg=DEFAULT_VALUE_ERROR.format(
+                            NAMEID_FORMAT_ENTITY)
                     ),
                     'NameQualifier': Equal(
-                            issuer_name, msg=DEFAULT_VALUE_ERROR.format(issuer_name)
-                        ),
+                        issuer_name, msg=DEFAULT_VALUE_ERROR.format(
+                            issuer_name)
+                    ),
                 },
                 'children': {},
                 'text': str,
@@ -279,7 +287,8 @@ class SpidValidator(object):
                 'attrs': {
                     'NameQualifier': str,
                     'Format': Equal(
-                        NAMEID_FORMAT_TRANSIENT, msg=DEFAULT_VALUE_ERROR.format(NAMEID_FORMAT_TRANSIENT)
+                        NAMEID_FORMAT_TRANSIENT, msg=DEFAULT_VALUE_ERROR.format(
+                            NAMEID_FORMAT_TRANSIENT)
                     ),
                 },
                 'children': {},
@@ -292,7 +301,8 @@ class SpidValidator(object):
             {
                 'attrs': {
                     'Format': Equal(
-                        NAMEID_FORMAT_TRANSIENT, msg=DEFAULT_VALUE_ERROR.format(NAMEID_FORMAT_TRANSIENT)
+                        NAMEID_FORMAT_TRANSIENT, msg=DEFAULT_VALUE_ERROR.format(
+                            NAMEID_FORMAT_TRANSIENT)
                     ),
                 },
                 'children': {},
@@ -359,7 +369,8 @@ class SpidValidator(object):
             {
                 'attrs': {
                     'Format': Equal(
-                        NAMEID_FORMAT_ENTITY, msg=DEFAULT_VALUE_ERROR.format(NAMEID_FORMAT_ENTITY)
+                        NAMEID_FORMAT_ENTITY, msg=DEFAULT_VALUE_ERROR.format(
+                            NAMEID_FORMAT_ENTITY)
                     ),
                     'NameQualifier': str
                 },
@@ -374,34 +385,31 @@ class SpidValidator(object):
         def check_assertion_consumer_service(attrs):
             keys = attrs.keys()
             if (
-                'AssertionConsumerServiceURL' in keys
-                and 'ProtocolBinding' in keys
-                and 'AssertionConsumerServiceIndex' not in keys
+                'AssertionConsumerServiceURL' in keys and 'ProtocolBinding' in keys and 'AssertionConsumerServiceIndex' not in keys
             ):
                 _errors = []
                 if attrs['ProtocolBinding'] != BINDING_HTTP_POST:
                     _errors.append(
-                    Invalid(
-                        DEFAULT_VALUE_ERROR.format(BINDING_HTTP_POST), path=['ProtocolBinding']
-                    )
+                        Invalid(
+                            DEFAULT_VALUE_ERROR.format(BINDING_HTTP_POST), path=['ProtocolBinding']
+                        )
                     )
                 if attrs['AssertionConsumerServiceURL'] not in assertion_consumer_service_urls:
                     _errors.append(
                         Invalid(
-                        DEFAULT_VALUE_ERROR.format(assertion_consumer_service_urls), path=['AssertionConsumerServiceURL'])
+                            DEFAULT_VALUE_ERROR.format(assertion_consumer_service_urls), path=['AssertionConsumerServiceURL'])
                     )
                 if _errors:
                     raise MultipleInvalid(errors=_errors)
                 return attrs
 
             elif (
-                'AssertionConsumerServiceURL' not in keys
-                and 'ProtocolBinding' not in keys
-                and 'AssertionConsumerServiceIndex' in keys
+                'AssertionConsumerServiceURL' not in keys and 'ProtocolBinding' not in keys and 'AssertionConsumerServiceIndex' in keys
             ):
                 if attrs['AssertionConsumerServiceIndex'] not in assertion_consumer_service_indexes:
                     raise Invalid(
-                        DEFAULT_LIST_VALUE_ERROR.format(assertion_consumer_service_indexes),
+                        DEFAULT_LIST_VALUE_ERROR.format(
+                            assertion_consumer_service_indexes),
                         path=['AssertionConsumerServiceIndex'])
                 return attrs
 
@@ -421,7 +429,8 @@ class SpidValidator(object):
                     Optional('ForceAuthn'): str,
                     Optional('AttributeConsumingServiceIndex'): In(
                         attribute_consuming_service_indexes,
-                        msg=DEFAULT_LIST_VALUE_ERROR.format(attribute_consuming_service_indexes)
+                        msg=DEFAULT_LIST_VALUE_ERROR.format(
+                            attribute_consuming_service_indexes)
                     ),
                     Optional('AssertionConsumerServiceIndex'): str,
                     Optional('AssertionConsumerServiceURL'): str,
@@ -491,20 +500,22 @@ class SpidValidator(object):
                 _new_sub_schema = authnrequest_schema[
                     AUTHNREQUEST_TAG
                 ]['children'].extend(
-                        {
-                            '{%s}Signature' % (SIGNATURE) : signature
-                        }
-                    )
-                authnrequest_schema[AUTHNREQUEST_TAG]['children'] = _new_sub_schema
+                    {
+                        '{%s}Signature' % (SIGNATURE): signature
+                    }
+                )
+                authnrequest_schema[AUTHNREQUEST_TAG][
+                    'children'] = _new_sub_schema
             if self._action == 'logout':
                 _new_sub_schema = logoutrequest_schema[
                     LOGOUTREQUEST_TAG
                 ]['children'].extend(
-                        {
-                            '{%s}Signature' % (SIGNATURE) : signature
-                        }
-                    )
-                logoutrequest_schema[LOGOUTREQUEST_TAG]['children'] = _new_sub_schema
+                    {
+                        '{%s}Signature' % (SIGNATURE): signature
+                    }
+                )
+                logoutrequest_schema[LOGOUTREQUEST_TAG][
+                    'children'] = _new_sub_schema
 
         authn_request = Schema(
             authnrequest_schema,

--- a/tox.ini
+++ b/tox.ini
@@ -38,3 +38,15 @@ skip_install = true
 deps = isort
 commands = isort -c -rc -df spid-testenv.py testenv
 skip_install = true
+
+#
+# Give code a consistent format.
+#
+[testenv:reformat]
+deps =
+    autopep8
+    isort
+commands = 
+    autopep8 -ri spid-testenv.py testenv
+    isort -rc -y spid-testenv.py testenv
+


### PR DESCRIPTION
@alexrj 

## This PR

Fixes flake8 and returns a successful build. This allows every PR to be visibly validated. 

## It's done    

  - Fix spacing compliance to pep8 via  `autopep8 --recursive --in-place *.py testenv/`
  - Remove unused import and variables
  - Add `# noqa` to lines where compliance can't be enforced
  - Exclude checks via `setup.cfg;[flake8]` configuration.

## Notes

  - the excluded checks (line-too-long) are now documented and   explicit. 
  - when we want to enforce them, we should clean the code first.