### PR TITLE
Add test: validate saml with xsd. #145

### DIFF
--- a/testenv/tests/test_saml.py
+++ b/testenv/tests/test_saml.py
@@ -8,6 +8,8 @@ from lxml import etree
 from testenv.saml import create_response
 from testenv.settings import SAML, SAMLP, SPID_LEVEL_1, STATUS_SUCCESS
 
+from .utils import validate_xml
+
 
 class SamlElementTestCase(unittest.TestCase):
 
@@ -99,3 +101,6 @@ class SamlElementTestCase(unittest.TestCase):
             self.assertEqual(issuer.text, 'http://test_id.entity')
         self.assertEqual(issuers[0].getparent().tag, '{%s}Response' % SAMLP)
         self.assertEqual(issuers[1].getparent().tag, '{%s}Assertion' % SAML)
+
+        self.assertTrue(validate_xml(response.to_xml(), 'testenv/xsd/saml-schema-protocol-2.0.xsd'),
+                        "The resulting XML is invalid")

--- a/testenv/tests/utils.py
+++ b/testenv/tests/utils.py
@@ -1,7 +1,27 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from lxml import etree
+
+try:
+    # Replace this try-except with
+    # from six.moves import StringIO
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+
+def validate_xml(xml_string, xsd_path):
+    with open(xsd_path) as fh:
+        xmlschema_doc = etree.parse(fh)
+    xmlschema = etree.XMLSchema(xmlschema_doc)
+    # Decode bytes object and preserve strings and unicode(py2).
+    if isinstance(xml_string, bytes):
+        xml_string = xml_string.decode("utf-8")
+    return xmlschema.validate(etree.parse(StringIO(xml_string)))
+
 
 class FakeRequest(object):
+
     def __init__(self, data):
         self.saml_request = data


### PR DESCRIPTION




@alexrj 

## This PR  

Add a test which fails when the generated response
  is not valid saml. This should help in reproducing #159 too.

## It's done

Via lxml xsd parser/validator.

## Note

Given that:
  - `six` is not in requirements.txt 
  -  but it's used testenv/tests/test_spid_testenv.py, probably inherited by `tox`

I used
  -  `try... except ImportError` (see utils.py) instead of `from six.moves import StringIO`

Consider adding `six` to `requirements.txt`
