### PR TITLE
add reverse proxy support

### DIFF
--- a/spid-testenv.py
+++ b/spid-testenv.py
@@ -6,6 +6,7 @@ import os
 import os.path
 
 from flask import Flask
+from werkzeug.contrib.fixers import ProxyFix
 
 from testenv import config, spmetadata
 from testenv.exceptions import BadConfiguration
@@ -29,5 +30,8 @@ if __name__ == '__main__':
     else:
         spmetadata.build_metadata_registry()
         os.environ['FLASK_ENV'] = 'development'
-        server = IdpServer(app=Flask(__name__, static_url_path='/static'))
+        app = Flask(__name__, static_url_path='/static')
+        if config.params.behind_reverse_proxy:
+            app.wsgi_app = ProxyFix(app.wsgi_app)
+        server = IdpServer(app=app)
         server.start()

--- a/testenv/config.py
+++ b/testenv/config.py
@@ -30,6 +30,7 @@ class ConfigValidator(object):
             'https_cert_file': str,
             'https_key_file': str,
             'users_file': str,
+            'behind_reverse_proxy': bool,
             'endpoints': {
                 'single_logout_service': str,
                 'single_sign_on_service': str,
@@ -230,6 +231,10 @@ class Config(object):
                 'loglevel': 'debug',
             }
         }
+
+    @property
+    def behind_reverse_proxy(self):
+        return self._confdata.get('behind_reverse_proxy', False)
 
     def receivers(self, service):
         entity_id = self.entity_id.rstrip('/')


### PR DESCRIPTION
Questa PR aggiunge supporto all'esecuzione dell'applicazione dietro un reverse proxy.
Il tentativo è quello di implementare tale feature senza cambiare l'esperienza d'uso nello scenario di proxy assente.
La funzionalità fa leva su degli header che il proxy invia all'applicazione; come misura di sicurezza, è stata introdotta una nuova direttiva nella configurazione (`behind_reverse_proxy`) che consente di abilitare la feature solo quando si ha pieno controllo del proxy.

L'implementazione è stata testata con la seguente configurazione nginx:
```
server {
    listen 8090 ssl;

    ssl_certificate     /path/to/cert;
    ssl_certificate_key /path/to/key;

    server_name spid-nginx.local;

    access_log  /var/log/nginx/access.log;
    error_log  /var/log/nginx/error.log;

    location / {
        proxy_pass         http://127.0.0.1:8088/;
        proxy_redirect     off;

        proxy_set_header   Host                 $http_host;
        proxy_set_header   X-Real-IP            $remote_addr;
        proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
        proxy_set_header   X-Forwarded-Proto    $scheme;
    }
}
```