### PR TITLE
Make NameFormat optional in metadata validator. Fix issue #195

### DIFF
--- a/testenv/saml.py
+++ b/testenv/saml.py
@@ -592,7 +592,8 @@ def create_sp_metadata(
     attribute_consuming_services=None,
     single_logout_services=None,
     md_id=None,
-    check_attributes=True
+    check_attributes=True,
+    name_format=True
 ):
     _id = generate_unique_id() if md_id is None else md_id
     entity_descriptor = EntityDescriptor(
@@ -667,11 +668,13 @@ def create_sp_metadata(
                 ] or attr_name in SPID_ATTRIBUTES[
                     'secondary'
                 ] or not check_attributes:
+                    _attrib = {
+                        'Name': attr_name
+                    }
+                    if name_format:
+                        _attrib['NameFormat'] = NAME_FORMAT_BASIC
                     requested_attribute = RequestedAttribute(
-                        attrib=dict(
-                            Name=attr_name,
-                            NameFormat=NAME_FORMAT_BASIC
-                        )
+                        attrib=_attrib
                     )
                     attribute_consuming_service.append(requested_attribute)
             sp_sso_descriptor.append(attribute_consuming_service)

--- a/testenv/tests/test_validators.py
+++ b/testenv/tests/test_validators.py
@@ -555,3 +555,25 @@ class SpidMetadataValidatorTestCase(unittest.TestCase):
         )
         self.assertEqual('non corrisponde a nessuno dei valori contenuti in {}'.format(
             settings.SPID_ATTRIBUTES_NAMES), exc.details[0].message)
+
+    @patch('testenv.validators._check_certificate', side_effect=fake_check_certificate)
+    def test_no_name_format(self, mocked):
+        FakeConfig('http://localhost:8088/sso', 'http://localhost:8088/')
+        validator = SpidMetadataValidator()
+        metadata = create_sp_metadata(
+            entity_id='http://test.sp',
+            authn_request_signed='true',
+            assertion_consumer_services=[Acs(location='http://test.sp/acs')],
+            attribute_consuming_services=[
+                Atcs(
+                    service_name='test_1',
+                    attributes=['spidCode']
+                )
+            ],
+            single_logout_services=[
+                Slo(binding=BINDING_HTTP_POST, location='http://test.sp/slo')
+            ],
+            keys=[Key('signing', 'somevalue123')],
+            name_format=False
+        ).to_xml()
+        validator.validate(metadata)

--- a/testenv/validators.py
+++ b/testenv/validators.py
@@ -328,7 +328,7 @@ class SpidMetadataValidator(object):
                             [{
                                 'attrs': {
                                     'Name': All(str, In(SPID_ATTRIBUTES_NAMES, msg=DEFAULT_LIST_VALUE_ERROR.format(SPID_ATTRIBUTES_NAMES))),
-                                    'NameFormat': Equal(
+                                    Optional('NameFormat'): Equal(
                                         NAME_FORMAT_BASIC, msg=DEFAULT_VALUE_ERROR.format(
                                             NAME_FORMAT_BASIC)
                                     ),


### PR DESCRIPTION
fix #195 