### PR TITLE
Allow both entityID and endpoint URL for Destination attribute

### DIFF
--- a/testenv/config.py
+++ b/testenv/config.py
@@ -185,6 +185,14 @@ class Config(object):
         }
 
     @property
+    def absolute_sso_url(self):
+        return self.entity_id + self.endpoints.get('single_sign_on_service')
+
+    @property
+    def absolute_slo_url(self):
+        return self.entity_id + self.endpoints.get('single_logout_service')
+
+    @property
     def metadata(self):
         return deepcopy(self._confdata.get('metadata', {}))
 

--- a/testenv/server.py
+++ b/testenv/server.py
@@ -873,33 +873,30 @@ class IdpServer(object):
         with open(cert_file, 'r') as fp:
             cert = fp.readlines()[1:-1]
             cert = ''.join(cert)
-        endpoints = self._config.endpoints
-        sso = self._config.entity_id + endpoints.get('single_sign_on_service')
-        slo = self._config.entity_id + endpoints.get('single_logout_service')
         sso_list = []
         slo_list = []
         sso_list.append(
             Sso(
                 binding=BINDING_HTTP_POST,
-                location=sso
+                location=self._config.absolute_sso_url
             )
         )
         sso_list.append(
             Sso(
                 binding=BINDING_HTTP_REDIRECT,
-                location=sso
+                location=self._config.absolute_sso_url
             )
         )
         slo_list.append(
             Slo(
                 binding=BINDING_HTTP_POST,
-                location=slo
+                location=self._config.absolute_slo_url
             )
         )
         slo_list.append(
             Slo(
                 binding=BINDING_HTTP_REDIRECT,
-                location=slo
+                location=self._config.absolute_slo_url
             )
         )
         metadata = create_idp_metadata(

--- a/testenv/tests/data/sample_saml_requests.py
+++ b/testenv/tests/data/sample_saml_requests.py
@@ -102,7 +102,7 @@ missing_issuer = """\
 """
 
 wrong_destination = """\
-<saml2p:AuthnRequest ForceAuthn="false" AssertionConsumerServiceURL="http://localhost:3000/spid-sso" ID="_980c46de183f4818b1f765dfb22fd1dc" Destination="http://localhost:8088/sso" IssueInstant="2018-08-18T06:57:22Z" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
+<saml2p:AuthnRequest ForceAuthn="false" AssertionConsumerServiceURL="http://localhost:3000/spid-sso" ID="_980c46de183f4818b1f765dfb22fd1dc" Destination="http://localhost:8088/foobar" IssueInstant="2018-08-18T06:57:22Z" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
     <saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity" NameQualifier="https://localhost:8088/">https://localhost:8088/</saml2:Issuer>%s<saml2p:NameIDPolicy Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"></saml2p:NameIDPolicy>
     <saml2p:RequestedAuthnContext Comparison="minimum">
         <saml2:AuthnContextClassRef>https://www.spid.gov.it/SpidL1</saml2:AuthnContextClassRef>

--- a/testenv/tests/test_validators.py
+++ b/testenv/tests/test_validators.py
@@ -50,11 +50,11 @@ class FakeConfig(object):
 
     @property
     def absolute_sso_url(self):
-        return self.entity_id + self.endpoints.get('single_sign_on_service')
+        return self._endpoint
 
     @property
     def absolute_slo_url(self):
-        return self.entity_id + self.endpoints.get('single_logout_service')
+        return self._endpoint
 
 
 class FakeMetadata(dict):

--- a/testenv/tests/test_validators.py
+++ b/testenv/tests/test_validators.py
@@ -48,6 +48,14 @@ class FakeConfig(object):
     def entity_id(self, *args, **kwargs):
         return self._entity_id
 
+    @property
+    def absolute_sso_url(self):
+        return self.entity_id + self.endpoints.get('single_sign_on_service')
+
+    @property
+    def absolute_slo_url(self):
+        return self.entity_id + self.endpoints.get('single_logout_service')
+
 
 class FakeMetadata(dict):
 

--- a/testenv/validators.py
+++ b/testenv/validators.py
@@ -681,8 +681,9 @@ class SpidRequestValidator(object):
                     'ID': str,
                     'Version': Equal('2.0', msg=DEFAULT_VALUE_ERROR.format('2.0')),
                     'IssueInstant': All(str, _check_utc_date, self._check_date_in_range),
-                    'Destination': Equal(
-                        entity_id, msg=DEFAULT_VALUE_ERROR.format(entity_id)
+                    'Destination': In(
+                        [entity_id, self._config.absolute_sso_url],
+                        msg=DEFAULT_VALUE_ERROR.format(entity_id)
                     ),
                     Optional('ForceAuthn'): str,
                     Optional('AttributeConsumingServiceIndex'): In(
@@ -729,8 +730,9 @@ class SpidRequestValidator(object):
                     'ID': str,
                     'Version': Equal('2.0', msg=DEFAULT_VALUE_ERROR.format('2.0')),
                     'IssueInstant': All(str, _check_utc_date, self._check_date_in_range),
-                    'Destination': Equal(
-                        entity_id, msg=DEFAULT_VALUE_ERROR.format(entity_id)
+                    'Destination': In(
+                        [entity_id, self._config.absolute_sso_url],
+                        msg=DEFAULT_VALUE_ERROR.format(entity_id)
                     ),
                     Optional('NotOnOrAfter'): All(str, _check_utc_date, self._check_date_not_expired),
                     Optional('Reason'): str,


### PR DESCRIPTION
As per the [Avviso 11](https://www.agid.gov.it/it/piattaforme/spid/avvisi-spid) the SPID rules were fixed in order to allow the Destination attribute to be populated according to the SAML spec, thus with the URL of the endpoint instead of the entityID.

This fixes #217 by allowing both values.