### PR TITLE
Use the -slim variant as base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.5-slim
 
 # Install prerequisites
 RUN apt-get update -y && apt-get install -y ca-certificates xmlsec1 libffi6


### PR DESCRIPTION
Use 3.5-slim as base image and save ~700MiB. Yay!