### PR TITLE
Use yaml.safe_load() instead of yaml.load().

### DIFF
--- a/testenv/config.py
+++ b/testenv/config.py
@@ -293,7 +293,7 @@ class BaseConfigParser(object):
 class YAMLConfigParser(BaseConfigParser):
 
     def _deserialize(self):
-        return yaml.load(self._fp)
+        return yaml.safe_load(self._fp)
 
 
 class JSONConfigParser(BaseConfigParser):


### PR DESCRIPTION
Use yaml.safe_load() in order to suppress pyyaml's warnings.

Security-wise it shouldn't change much, as config.yaml should
already be trusted input (but it might not be in the future).