### PR TITLE
Get rid of requests' + urllib3 warning.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ signxml==2.5.2
 six==1.11.0
 sqlalchemy==1.2.12
 text-unidecode==1.2       # via faker
+typing==3.6.6             # via importlib-resources
 urllib3==1.24.3           # via requests
 voluptuous==0.11.5
 werkzeug==0.15.3          # via flask


### PR DESCRIPTION
Re-run pip-compile and get rid of requests' warning about unsupported
urllib3 version.