### PR TITLE
Add view users configuration flag

### DIFF
--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -53,7 +53,7 @@ users_file: "conf/users.json"
 can_add_user: true
 
 # Abilita (true) o disabilita (false) la possibilità di visualizzare la sezione utenti
-can_add_user: true
+can_view_users: true
 
 # Abilita (true) o disbilita (false) l'interfaccia /admin che consente di gestire 
 # gli oggetti nel database

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -52,6 +52,9 @@ users_file: "conf/users.json"
 # Abilita (true) o disabilita (false) la possibilità di aggiungere nuovi utenti
 can_add_user: true
 
+# Abilita (true) o disabilita (false) la possibilità di aggiungere nuovi utenti
+can_add_user: true
+
 # Abilita (true) o disbilita (false) l'interfaccia /admin che consente di gestire 
 # gli oggetti nel database
 database_admin_interface: false

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -52,7 +52,7 @@ users_file: "conf/users.json"
 # Abilita (true) o disabilita (false) la possibilità di aggiungere nuovi utenti
 can_add_user: true
 
-# Abilita (true) o disabilita (false) la possibilità di aggiungere nuovi utenti
+# Abilita (true) o disabilita (false) la possibilità di visualizzare la sezione utenti
 can_add_user: true
 
 # Abilita (true) o disbilita (false) l'interfaccia /admin che consente di gestire 

--- a/templates/admin_area_base.html
+++ b/templates/admin_area_base.html
@@ -41,8 +41,10 @@
           <li class="nav-item active"><a class="nav-link active" href="/"><span>Home</span><span
                 class="sr-only">current</span></a>
           </li>
+           {% if can_view_users %}
           <li class="nav-item"><a class="nav-link" href="/users"><span>Utenti</span></a>
           </li>
+           {% endif %}
           <li class="nav-item"><a class="nav-link" href="/metadata"><span>Metadata IdP</span></a></li>
         </ul>
       </div>

--- a/testenv/config.py
+++ b/testenv/config.py
@@ -32,6 +32,7 @@ class ConfigValidator(object):
             'users_file': str,
             'behind_reverse_proxy': bool,
             'can_add_user': bool,
+            'can_view_users': bool,
             'storage': All(str, In(['file', 'postgres'])),
             'db_url': str,
             'endpoints': {
@@ -172,6 +173,10 @@ class Config(object):
     @property
     def can_add_user(self):
         return self._confdata.get('can_add_user', True)
+
+    @property
+    def can_view_users(self):
+        return self._confdata.get('can_view_users', True)
 
     @property
     def database_admin_interface(self):

--- a/testenv/server.py
+++ b/testenv/server.py
@@ -113,10 +113,11 @@ class IdpServer(object):
         self.app.add_url_rule(
             '/login', 'login', self.login, methods=['POST', 'GET']
         )
-        # Endpoint for user add action
-        self.app.add_url_rule(
-            '/users', 'users', self.users, methods=['GET', 'POST']
-        )
+        if self._config.can_view_users:
+            # Endpoint for user add action
+            self.app.add_url_rule(
+                '/users', 'users', self.users, methods=['GET', 'POST']
+            )
         self.app.add_url_rule(
             '/continue-response', 'continue_response',
             self.continue_response, methods=['POST']
@@ -353,7 +354,8 @@ class IdpServer(object):
                 'secondary_attributes': spid_secondary_fields,
                 'users': self.user_manager.all(),
                 'sp_list': self._registry.all(),
-                'can_add_user': can_add_user
+                'can_add_user': can_add_user,
+                'can_view_users': self._config.can_view_users
             }
         )
         if request.method == 'GET':
@@ -391,6 +393,7 @@ class IdpServer(object):
                         "entityID": sp
                     } for sp in self._registry.all()
                 ],
+            'can_view_users': self._config.can_view_users
             }
         )
         return rendered_form, 200

--- a/testenv/server.py
+++ b/testenv/server.py
@@ -393,7 +393,7 @@ class IdpServer(object):
                         "entityID": sp
                     } for sp in self._registry.all()
                 ],
-            'can_view_users': self._config.can_view_users
+                'can_view_users': self._config.can_view_users
             }
         )
         return rendered_form, 200

--- a/testenv/server.py
+++ b/testenv/server.py
@@ -346,6 +346,7 @@ class IdpServer(object):
         spid_main_fields = self._spid_main_fields
         spid_secondary_fields = self._spid_secondary_fields
         can_add_user = self._config.can_add_user
+        can_view_users = self._config.can_view_users
         rendered_form = render_template(
             "users.html",
             **{
@@ -355,7 +356,7 @@ class IdpServer(object):
                 'users': self.user_manager.all(),
                 'sp_list': self._registry.all(),
                 'can_add_user': can_add_user,
-                'can_view_users': self._config.can_view_users
+                'can_view_users': can_view_users
             }
         )
         if request.method == 'GET':


### PR DESCRIPTION
This PR adds the **can_view_users** configuration flag to enable/disable the access to users list section

| flag on  | flag off |
| ------------- | ------------- |
![Preferences](https://user-images.githubusercontent.com/822471/68961750-5db72900-07d3-11ea-802d-c8440a63a5db.png) | ![Privacy](https://user-images.githubusercontent.com/822471/68961751-5e4fbf80-07d3-11ea-8ff6-3da3c17e71a8.png)



