### PR TITLE
Default config in container if none available.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,14 @@ COPY ./requirements.txt /app/requirements.txt
 WORKDIR /app
 RUN pip install -r requirements.txt
 
+# When started, the container checks for the required configuration files
+# and if it can't find them, it uses the example files to make the server
+# start.
+#
+# The example files won't be available if the user rebinds /app/conf,
+# so we make a copy somewhere else.
+COPY conf/*.example conf/*.example /usr/local/share/spid-testenv2/
+
 # Copy the full application in a single layer
 COPY . /app
 

--- a/README.md
+++ b/README.md
@@ -59,20 +59,12 @@ Per ottenere la persistenza della configurazione è necessario creare nell'host 
 mkdir /etc/spid-testenv2
 ```
 
-Creare nella directory il file config.yaml e la coppia chiave/certificato per l'IdP, nonché eventuali metadata SP, come indicato nel paragrafo successivo.
-
 Creare il container con il seguente comando:
 
 ```
-docker create --name spid-testenv2 -p 8088:8088 --restart=always \
+docker run --name spid-testenv2 -p 8088:8088 --restart=always \
    --mount src="/etc/spid-testenv2",target="/app/conf",type=bind \
    italia/spid-testenv2
-```
-
-Avviare il container:
-
-```
-docker start spid-testenv2
 ```
 
 Il log si può visualizzare con il comando:
@@ -80,6 +72,9 @@ Il log si può visualizzare con il comando:
 ```
 docker logs -f spid-testenv2
 ```
+
+I file `/etc/spid-testenv2/config.yaml` e `/etc/spid-testenv2/sp_metadata.xml` possono
+essere modificati a seconda delle esigenze.
 
 ## Configurazione
 

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -18,8 +18,8 @@ cert_file: "./conf/idp.crt"
 metadata:
    # Sono supportati anche metacaratteri,
    # es: "*.xml", "sp_metadat?.xml" o "sp[-_]metadat[a-z].xml"
-#  local:
-#    - "./conf/sp_metadata.xml"
+  local:
+    - "./conf/sp_metadata.xml"
 #  remote:
 #    - "http://spid-sp/metadata"
 #  db: 'postgresql+psycopg2://postgres:@localhost:5432/exampledb'

--- a/conf/sp_metadata.xml.example
+++ b/conf/sp_metadata.xml.example
@@ -6,7 +6,7 @@
 <md:EntityDescriptor
     xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-    entityID="https://www.myserviceprovider.it/"
+    entityID="https://myserviceprovider.example.com/"
     ID="_681a637-6cd4-434f-92c3-4fed720b2ad8">
 
     <!-- Il certificato del Service Provider va riportato nei due tag KeyDescriptor
@@ -35,7 +35,7 @@
         <!-- Endpoint del Service Provider deputato a ricevere le LogoutRequest -->
         <md:SingleLogoutService
             Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-            Location="https://www.myserviceprovider.it/spid/logout" />
+            Location="https://myserviceprovider.example.com/spid/logout" />
 
         <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
 
@@ -43,7 +43,7 @@
              (può essere ripetuto più volte, incrementando l'attributo index) -->
         <md:AssertionConsumerService
             Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-            Location="https://www.myserviceprovider.it/spid/acs"
+            Location="https://myserviceprovider.example.com/spid/acs"
             index="0"
             isDefault="true" />
 
@@ -78,7 +78,7 @@
     <md:Organization>
         <md:OrganizationName xml:lang="it">Nome del Service Provider</md:OrganizationName>
         <md:OrganizationDisplayName xml:lang="it">Nome completo del Service Provider</md:OrganizationDisplayName>
-        <md:OrganizationURL xml:lang="it">https://www.myserviceprovider.it/</md:OrganizationURL>
+        <md:OrganizationURL xml:lang="it">https://myserviceprovider.example.com/</md:OrganizationURL>
     </md:Organization>
 
 </md:EntityDescriptor>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,11 @@ set -eu
 KEY_FILE=conf/idp.key
 CRT_FILE=conf/idp.crt
 
+CONFIG_YAML=conf/config.yaml
+SP_METADATA=conf/sp_metadata.xml
+
+EXAMPLES_DIR=/usr/local/share/spid-testenv2/
+
 if [ ! -e $KEY_FILE ] && [ ! -e $CRT_FILE ]; then
     echo "Generating $KEY_FILE and $CRT_FILE..."
     openssl req -x509 \
@@ -13,6 +18,16 @@ if [ ! -e $KEY_FILE ] && [ ! -e $CRT_FILE ]; then
                 -newkey rsa:2048 \
                 -keyout $KEY_FILE \
                 -out $CRT_FILE
+fi
+
+if [ ! -e $CONFIG_YAML ]; then
+    echo "Using default $CONFIG_YAML..."
+    cp $EXAMPLES_DIR/config.yaml.example $CONFIG_YAML
+fi
+
+if [ ! -e $SP_METADATA ]; then
+    echo "Using default $SP_METADATA..."
+    cp $EXAMPLES_DIR/sp_metadata.xml.example $SP_METADATA
 fi
 
 exec "$@"


### PR DESCRIPTION
Use a default configuration when starting the container if there is
none.

Fix #238.