### PR TITLE
Refactor the SP metadata loading logic.

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -10,8 +10,11 @@
       <tbody>
         {% for item in sp_list %}
             <tr>
-                <td >
-                   {{ item['entityID'] }}
+                <td>
+                    {{ item['entityID'] }}
+                    <small class="float-right">
+                        <mark>loaded from {{ item['location'] }}</mark>
+                    </small>
                 </td>
            </tr>
         {% endfor %}

--- a/testenv/server.py
+++ b/testenv/server.py
@@ -284,7 +284,7 @@ class IdpServer:
 
     def _get_certificates_by_issuer(self, issuer):
         try:
-            return self._registry.get(issuer).certs()
+            return self._registry.load(issuer).certs()
         except KeyError:
             self._raise_error(
                 'entity ID {} non registrato, impossibile ricavare'
@@ -357,7 +357,7 @@ class IdpServer:
                 'primary_attributes': spid_main_fields,
                 'secondary_attributes': spid_secondary_fields,
                 'users': self.user_manager.all(),
-                'sp_list': self._registry.all(),
+                'sp_list': self._registry.load_all().keys(),
                 'can_add_user': can_add_user
             }
         )
@@ -393,8 +393,9 @@ class IdpServer:
             **{
                 'sp_list': [
                     {
-                        "entityID": sp
-                    } for sp in self._registry.all()
+                        "entityID": entity_id,
+                        "location": sp_metadata.location,
+                    } for (entity_id, sp_metadata) in self._registry.load_all().items()
                 ],
             }
         )
@@ -405,7 +406,7 @@ class IdpServer:
         acs_index = getattr(req, 'assertion_consumer_service_index', None)
         protocol_binding = getattr(req, 'protocol_binding', None)
         if acs_index is not None:
-            acss = self._registry.get(
+            acss = self._registry.load(
                 sp_id).assertion_consumer_service(index=acs_index)
             if acss:
                 destination = acss[0].get('Location')
@@ -590,7 +591,7 @@ class IdpServer:
                                 atcs_idx
                             )
                         )
-                        sp_metadata = self._registry.get(sp_id)
+                        sp_metadata = self._registry.load(sp_id)
                         required = []
                         optional = []
                         if atcs_idx and sp_metadata:
@@ -791,7 +792,7 @@ class IdpServer:
     def _sp_single_logout_service(self, issuer_name):
         _slo = None
         try:
-            _slo = self._registry.get(issuer_name).single_logout_services[0]
+            _slo = self._registry.load(issuer_name).single_logout_services[0]
         except Exception:
             pass
         return _slo

--- a/testenv/tests/test_spid_testenv.py
+++ b/testenv/tests/test_spid_testenv.py
@@ -29,7 +29,7 @@ DATA_DIR = 'testenv/tests/data/'
 
 
 def _sp_single_logout_service(server, issuer_name, binding):
-    _slo = server._registry.get(issuer_name).single_logout_service(
+    _slo = server._registry.load(issuer_name).single_logout_service(
         binding=binding
     )
     return _slo[0]

--- a/testenv/tests/test_validators.py
+++ b/testenv/tests/test_validators.py
@@ -68,7 +68,7 @@ class FakeRegistry:
     def __init__(self, metadata):
         self._metadata = metadata.copy()
 
-    def get(self, entity_id):
+    def load(self, entity_id):
         return self._metadata.get(entity_id)
 
     @property

--- a/testenv/validators.py
+++ b/testenv/validators.py
@@ -499,7 +499,7 @@ class SpidRequestValidator:
                 'Issuer non presente nella {}'.format(req_type)
             )
         try:
-            sp_metadata = self._registry.get(issuer_name)
+            sp_metadata = self._registry.load(issuer_name)
         except MetadataNotFoundError:
             raise UnknownEntityIDError(
                 'L\'entity ID "{}" indicato nell\'elemento <Issuer> non corrisponde a nessun Service Provider registrato in questo Identity Provider di test.'.format(issuer_name)


### PR DESCRIPTION
The SP metadata get loaded once at the start from all sources to
index the entities ids and where the come from.

Upon every request from an SP, the metadata of that SP gets reloaded
from the last known source: if it's not there anymore the server
tries to look in all known sources again.

Protip! Using:
```
metadata:
    local:
        - conf/*.xml
```

Allows to drop config files to the directory at runtime and have their
configuration picked up without restarting the server.

Other goodies:
* Invalid SP metadata are logged and discarded, but no longer prevent
  the rest of metadata from loading. (Fix #210)
* Duplicate entityIds are discarded with precedence given to local
  sources (local > db > remote) (Fix #205).
* Display the source of the SP metadata in the UI