### PR TITLE
Fix #292 Allow KeyName attribute in XML Signatures

### DIFF
--- a/testenv/validators.py
+++ b/testenv/validators.py
@@ -270,6 +270,11 @@ class SpidMetadataValidator:
                         ),
                     }, required=True),
                     'children': {
+                        Optional('{%s}KeyName' % (SIGNATURE)): {
+                            'attrs': {},
+                            'children': {},
+                            'text': str
+                        },
                         '{%s}KeyInfo' % (SIGNATURE): {
                             'attrs': {},
                             'children': {


### PR DESCRIPTION
Dalle Regole Tecniche, sezione Metadata:

```
Deve essere presente l’elemento <Signature> riportante la firma sui metadata. 
La firma deve essere prodotta secondo il profilo specificato per SAML (SAML-Metadata, cap. 3) 
utilizzando chiavi RSA almeno a 1024 bit e algoritmo di digest SHA-256 o superiore;
```

Relativamente all'elemento KeyInfo, le specifiche SAML-Metadata richiamate (https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf) rinviano alle specifiche XMLSig che prevedono un elemento opzionale detto "KeyName" (https://www.w3.org/TR/xmldsig-core2/#sec-KeyName).

Attualmente, SPID TestEnv, diversamente da SPID Validator, non accetta la presenza dell'elemento KeyName.