### PR TITLE
Update log.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
     && apt-get install -y \
         ca-certificates \
         xmlsec1 \
-        libffi6 \
+        libffi7 \
         build-essential \
         libpq-dev \
  && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
     && apt-get install -y \
         ca-certificates \
         xmlsec1 \
-        libffi \
+        libffi6 \
         build-essential \
         libpq-dev \
  && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
     && apt-get install -y \
         ca-certificates \
         xmlsec1 \
-        libffi7 \
+        libffi \
         build-essential \
         libpq-dev \
  && apt-get clean \

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ L'immagine `italia/spid-testenv2` a anche disponibile su [Docker Hub](https://hu
 
    Su macOS si può usare `brew install libxmlsec1 libffi`.
 
-   Su Debian/Ubuntu si può usare `apt-get install libxmlsec1 libffi6`.
+   Su Debian/Ubuntu si può usare `apt-get install libxmlsec1 libffi7`.
 
 1. Creare ed attivare un virtualenv
 

--- a/testenv/crypto.py
+++ b/testenv/crypto.py
@@ -290,7 +290,7 @@ class HTTPPostSignatureVerifier:
     def _verify_signature(self):
         try:
             self._verifier.verify(
-                self._request.saml_request, x509_cert=self._cert)
+                self._request.saml_request, x509_cert=self._cert, ignore_ambiguous_key_info=True)
         except InvalidDigest:
             self._fail('Il valore del digest non è valido.')
         except InvalidSignature_:

--- a/testenv/log.py
+++ b/testenv/log.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
 handler = RotatingFileHandler(
-    'spid.log', maxBytes=500000, backupCount=1
+    '/tmp/spid.log', maxBytes=500000, backupCount=1
 )
 handler.setLevel(logging.DEBUG)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(module)s - %(message)s')


### PR DESCRIPTION
Normalmente un container dovrebbe stampare i log su stdout. Se si vuole mantenere comunque un file di log propongo un
fix del path del file di log in conformità al paradigma del cloud dove le directory del codice sorgente sono immutabili e il container può anche essere eseguito con unutente differente che non ha permessi di scrittura come in OpenShift.